### PR TITLE
Import `execute-block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-io"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +419,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58"
@@ -1101,6 +1118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array 0.14.6",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1335,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1535,10 +1575,23 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+dependencies = [
+ "der 0.7.5",
+ "digest 0.10.6",
+ "elliptic-curve 0.13.4",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -1547,7 +1600,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1590,18 +1643,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.6",
- "ff",
+ "ff 0.12.1",
  "generic-array 0.14.6",
- "group",
+ "group 0.12.1",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.2",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array 0.14.6",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.1",
  "subtle",
  "zeroize",
 ]
@@ -1649,6 +1721,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1754,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "expander"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f360349150728553f92e4c997a16af8915f418d3a0f21b440d34c5632f16ed84"
+dependencies = [
+ "blake2",
+ "fs-err",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1708,6 +1804,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1827,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "frame-remote-externalities"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15a7ef4bdcbd8bdf1c874b5561d15124a0b4bb6daef696e5e0766bcfd8c9524"
+checksum = "13306364f34cda2e7cdf916d8468324733b2566777ffe6db9770e49d092cfbc0"
 dependencies = [
  "futures",
  "log",
@@ -1844,11 +1950,12 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48b2eab3ef942cce6cac08a72a690928746b9e430a2a3a65f41c76bc88c3f08"
+checksum = "80da0f683e5da274ff0401a02d16f4fb976686ed4286204fa00ab29207013d2c"
 dependencies = [
  "bitflags 1.3.2",
+ "environmental",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
@@ -1877,15 +1984,16 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9831759b9631b2dbd50a49ece3941fa5f2dfd0b73624b27e88ab4a6a46e6f679"
+checksum = "37e680991289aa3e7b11609228642df005edd888b72b52fbbabb361d2b7cb1ed"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "frame-support-procedural-tools",
  "itertools",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1917,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb535e39d0bd9e819d1f95031e013f5d767c5a9369af28dea61858daaca9d788"
+checksum = "71e2f824cfe5f945a24862233b17354542f57cd94e5bceddc8bf08ad84015ab0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1929,6 +2037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +2050,16 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fs4"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f5b6908aecca5812a4569056285e58c666588c9573ee59765bf1d3692699e2"
+dependencies = [
+ "rustix 0.37.19",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2092,6 +2216,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2180,7 +2305,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2206,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "hash-db"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
 
 [[package]]
 name = "hash256-std-hasher"
@@ -2587,13 +2723,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2628,7 +2764,7 @@ checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.11",
  "windows-sys 0.45.0",
 ]
 
@@ -2812,13 +2948,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.6",
+ "elliptic-curve 0.13.4",
+ "once_cell",
  "sha2 0.10.6",
 ]
 
@@ -2878,9 +3015,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -2963,7 +3100,7 @@ dependencies = [
  "prost-build",
  "rand 0.8.5",
  "rw-stream-sink",
- "sec1",
+ "sec1 0.3.0",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -3462,6 +3599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,7 +3712,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix",
+ "rustix 0.36.11",
 ]
 
 [[package]]
@@ -3592,15 +3735,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -3610,12 +3744,11 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
+checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3889,20 +4022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
-]
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,8 +4180,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
 ]
 
@@ -4072,8 +4191,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
 ]
 
@@ -4308,8 +4427,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.5",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -4469,10 +4598,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.52"
+name = "proc-macro-warning"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "9d4f284d87b9cedc2ff57223cbc4e3937cd6063c01e92c8e2a8c080df0013933"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -4882,9 +5022,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4944,7 +5094,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.3",
+ "nix",
  "thiserror",
  "tokio",
 ]
@@ -5016,11 +5166,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5094,9 +5258,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "sc-allocator"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa8784b53aa48736a4df4c351162a63b17e7c28c77b6a2e92dfb9bc49709107"
+checksum = "9125c40a62c10913294a32a27ec94453898198c41243c31c254c8d578df1c2bc"
 dependencies = [
  "log",
  "sp-core",
@@ -5106,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4d582801c5d5f8dcfcba46b4724958283fda6b6bb44540f0ba931da736add2"
+checksum = "0f1ab456d78be7888070f490c4bd7817961d298f2e8dc6f39fd6a17ba7b8e5a5"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5118,23 +5282,26 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09024be9bc50b0dd86dbf90f982ac83001b69459758db695663a14242ca8198"
+checksum = "bf07b2ff0b0a99662bd194699d8876ca9effe7b25b1f5ceaf4c980100e51448e"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
- "sc-network-common",
+ "sc-client-api",
+ "sc-executor",
+ "sc-network",
  "sc-telemetry",
  "serde",
  "serde_json",
+ "sp-blockchain",
  "sp-core",
  "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -5151,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbab387558faaad581ea2201862b3a84d097b0b6939a2e44f67ed59a3b6cced"
+checksum = "7dd6c15e1bfc8fc499477db332d3f963171328942f4aac8ec207fcda636b9bed"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -5192,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd2bd00e841dfb8db0b477e7a03f60fa9e79b5cefd4ec2013e212a3a86ebcd3"
+checksum = "659086026d731c1c503f1ca80073230cfab52afee990542e9146e8ee8fdc40d0"
 dependencies = [
  "fnv",
  "futures",
@@ -5219,9 +5386,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a32ed2f7983d5ec736371ff98b9f50dc26340194433fba4a1942c3b63557f38"
+checksum = "78f2188a7355b5997448788e175a7a44b0caa12eee505f291fb593aed51966d8"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5246,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fe228611617f1348a954e656b2b544eee5c0054000b712af8b0f05635b0015"
+checksum = "9f10906e2355075ee3bdb83a2cbca63523bb70a6222cbdfcbe08238c8bb585d1"
 dependencies = [
  "async-trait",
  "futures",
@@ -5272,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e73e3ece87f0d6ca9f3f1f903213ee8aab58287dc0b3921779afbf62d34411f"
+checksum = "9f56163cb9950689d8be465735982cf455d559d6bae7c65f01cf79fb32cc97e0"
 dependencies = [
  "lru",
  "parity-scale-codec",
@@ -5297,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff0b3bb1d41ca34481215297090496c35e91c6d66a71e3a26960c8fce917ea"
+checksum = "a039005564f63a1803e59888e0a0b9345d984d260bf8f8a3dfc06ab4d2d9ead1"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -5311,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a219dc830432961b377f28d50d8251b2f20c26471436c47cf5268126e8e9f"
+checksum = "511a186b611402910e35676fb5d2be66f98dd148c32f9ac0b7ee9a83a403ff3c"
 dependencies = [
  "log",
  "sc-allocator",
@@ -5325,16 +5492,16 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df03fdc79767bbc993cfcde07a8a09040e60fed1ca7341e3d17fc4c461e8457"
+checksum = "84c03401def5d2b833406713d0adcd3403e810e6c54b5f430e83c1e581a93882"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
  "log",
  "once_cell",
- "rustix",
+ "rustix 0.36.11",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -5344,15 +5511,16 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8de47ddefe4db4e5a48fce73301d5a9d1d8f68dbbb2c101662806f027b324"
+checksum = "6b5f3c621c7fb47d89165861545fd2f378d6a6aa77892cdee95c59913a2f5ad7"
 dependencies = [
  "ansi_term",
  "futures",
  "futures-timer",
  "log",
  "sc-client-api",
+ "sc-network",
  "sc-network-common",
  "sp-blockchain",
  "sp-runtime",
@@ -5360,9 +5528,9 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "15.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b46ca3ebdcfb0601eb512029ecf7d990fe7782b4773defded4419999a94d77"
+checksum = "123ef8b81039742fbfaf173d4191f4ad2cfdb872ac435fa2868236c964bfac07"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -5376,14 +5544,14 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a525c3f43fd1e9e09665763d0f0823699f5e78e31909b8949b03ad60a12806"
+checksum = "22f5ceb7e61b1b4fe1f640ee954190b9dfc084c0f3f9475f4a44b68b89ae7b60"
 dependencies = [
  "array-bytes",
+ "async-channel",
  "async-trait",
  "asynchronous-codec",
- "backtrace",
  "bytes",
  "either",
  "fnv",
@@ -5391,6 +5559,7 @@ dependencies = [
  "futures-timer",
  "ip_network",
  "libp2p",
+ "linked_hash_set",
  "log",
  "lru",
  "mockall",
@@ -5407,6 +5576,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "snow",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -5420,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-bitswap"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ffc1e06f8f7fc22ee3f89f919c3e0ebf778398afa9929211ac785c4fea7453"
+checksum = "4437607922226390fccfe7e947db38d7e3bf9f133725e3572ca150eb9e679fed"
 dependencies = [
  "cid",
  "futures",
@@ -5431,6 +5601,7 @@ dependencies = [
  "prost",
  "prost-build",
  "sc-client-api",
+ "sc-network",
  "sc-network-common",
  "sp-blockchain",
  "sp-runtime",
@@ -5440,36 +5611,38 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39d56f7508b31ac31144903cb2e48268842ec87d3fc5237772e29473868b27"
+checksum = "d84ad9e973f008f440c4b97e22f0d6d5225e7a09eecafd298f1cf52c448c84c5"
 dependencies = [
+ "array-bytes",
  "async-trait",
  "bitflags 1.3.2",
  "bytes",
  "futures",
  "futures-timer",
  "libp2p",
- "linked_hash_set",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
  "sc-peerset",
+ "sc-utils",
  "serde",
  "smallvec",
  "sp-blockchain",
  "sp-consensus",
- "sp-finality-grandpa",
+ "sp-consensus-grandpa",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8501bb2798aab09a0615d2ea64b080cb3e52aa64f5f6c6cb335be84b94517d1"
+checksum = "88d17e0d0bfd5fd4d47798a78a8efc8100eb53dc0244fa7e0403cb3579e698cc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -5479,6 +5652,7 @@ dependencies = [
  "prost",
  "prost-build",
  "sc-client-api",
+ "sc-network",
  "sc-network-common",
  "sc-peerset",
  "sp-blockchain",
@@ -5489,14 +5663,15 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49cd075b56a9de2bbf87ae32b2b297a68795ca0c3b75b623d0b2dead42992d4"
+checksum = "6847e00d1fadf31b50caaca6ca1fdb4739481d80e103b4cb1596ae7bd1a4985d"
 dependencies = [
  "array-bytes",
  "async-trait",
  "fork-tree",
  "futures",
+ "futures-timer",
  "libp2p",
  "log",
  "lru",
@@ -5506,6 +5681,7 @@ dependencies = [
  "prost-build",
  "sc-client-api",
  "sc-consensus",
+ "sc-network",
  "sc-network-common",
  "sc-peerset",
  "sc-utils",
@@ -5513,8 +5689,8 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
+ "sp-consensus-grandpa",
  "sp-core",
- "sp-finality-grandpa",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -5522,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df32255b31745a9eb7a47397993590d198f15cfeda342595aee96531b535bd5"
+checksum = "ec36a7534749886c7fabc17c24044966a7584b6edae4dad08de7a62239965639"
 dependencies = [
  "array-bytes",
  "futures",
@@ -5532,6 +5708,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "pin-project",
+ "sc-network",
  "sc-network-common",
  "sc-peerset",
  "sc-utils",
@@ -5542,9 +5719,9 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "19.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac7e29648bf3c0176eaf9cc3105ae56e105a995378ad0bee104b9deb8e6d128"
+checksum = "a0a66b0c49c4262814579cd95b396bea6f3261daa2cbe68276046dc76fbe68b1"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -5560,6 +5737,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "sc-client-api",
+ "sc-network",
  "sc-network-common",
  "sc-peerset",
  "sc-utils",
@@ -5573,9 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3db7a2b9fba75b084ea9a51b4911a99d9387777c60e2cfacfd60a3676ea788"
+checksum = "fc9731c05c36086cff3be45594a07d9dd951c7ac40ca0db1b6f5bd96bc591965"
 dependencies = [
  "futures",
  "libp2p",
@@ -5587,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "19.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ac425927dbd042a503a4b1f66aa0c2bf8f928f123de04ce0e742e13187edc3"
+checksum = "6b4ab32763fdc0fa24110110ceb629b4493d980525c2b3e21dd14538a7dc5e76"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5618,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb049c6dea3c497059f4a8c6153cb6715d1f0d9af74635f503114b46692685a0"
+checksum = "afe5794382859b074ead7a2a19f839b4e851aa6780f56687de0412e3e9e74e95"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5654,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34bdcc3a2438d55fba0c0f41daaf55c1486dd3a6ad90b49a9445cb60ca86f216"
+checksum = "bf2c53f64aea277e2ec170abc74a455554f624e4e561362dc5b45b7f66564fb0"
 dependencies = [
  "array-bytes",
  "futures",
@@ -5681,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc2a40325f8787399a08faf526a9c39f909bdf875fda39588f379d64eb0cde3"
+checksum = "f6a38ad87a5158e01e0e695fb022309a5d98c2b340029512a744597b9c83ae65"
 dependencies = [
  "async-trait",
  "directories",
@@ -5748,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5840303a4ad22baa8dfb4c3c11d9d3cb2c30a58206c1b54ab43a0970c5d0a94a"
+checksum = "9c60607de5e5c7ff91a0b90147209b838bace62ccc9b0b420b60a5c52f66ccd7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5760,14 +5938,14 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce555218b7cc4d23dd9fc5659ffc71e9a88c301278796056575f9c323a40df71"
+checksum = "2780c0052b5476dc2d17ce044ed9938599d4189f54d89731bf78622e9e82cfb0"
 dependencies = [
  "clap",
+ "fs4",
  "futures",
  "log",
- "nix 0.26.2",
  "sc-client-db",
  "sc-utils",
  "sp-core",
@@ -5777,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955f8ecc8db15842daa3d949128d6581b5613f074eedecac7868f3032a5881b5"
+checksum = "548e2cbc8ccfb49af6fb4483bffe14842922720569cc184ddd26e620d21eb651"
 dependencies = [
  "futures",
  "libc",
@@ -5797,9 +5975,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48c2f39c9ba57b56877bedb7cf726a4f378969e87db9fdbc1feb8f6e34161e2"
+checksum = "4871519fcc5ae2083a23a334461fd7e6d5b19e8f8d7f86dffe844de14dbb5bd9"
 dependencies = [
  "chrono",
  "futures",
@@ -5817,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535733abff4107ef013706053e4c6a9f6b308b097a55ba10aab160fd3163112a"
+checksum = "46b3ae6cd07244145e8367e2b2e5933f59f1600ba6e32309b59eefe0f005e82e"
 dependencies = [
  "ansi_term",
  "atty",
@@ -5861,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de562c901cf2e91a4406c281c27e790756b98f65602e0cf8bd136b83c5b0bc"
+checksum = "a6fa0d5ee5d2385a438c1bfc87ec7a5c8143abecd994df692889e33d0cdd3d8c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5889,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f2fa27a44912eeed796712b4b79fd5bb3c3763d54721e3414270123828054e"
+checksum = "3fb9259fbf4d6bb05314e8194b3b0484d1b85488109c75d724455c3817023c4a"
 dependencies = [
  "async-trait",
  "futures",
@@ -5904,17 +6082,18 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c227f2e96f3dca6f8a0dbd0d935ac273219365fc50d762d0328d66129fbd1c5e"
+checksum = "424e0af91552772a6c14a58be7b3d9db598cedbf2f3c4f1fc44c9e1d3139258f"
 dependencies = [
- "backtrace",
+ "async-channel",
  "futures",
  "futures-timer",
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
  "prometheus",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -5930,21 +6109,63 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d823d4be477fc33321f93d08fb6c2698273d044f01362dc27573a750deb7c233"
+checksum = "c7e5527e4b3bf079d4c0b2f253418598c380722ba37ef20fac9088081407f2b6"
 dependencies = [
  "parity-scale-codec",
+ "primitive-types",
  "scale-bits",
+ "scale-decode-derive",
  "scale-info",
  "thiserror",
 ]
 
 [[package]]
-name = "scale-info"
-version = "2.3.1"
+name = "scale-decode-derive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
+checksum = "b38741b2f78e4391b94eac6b102af0f6ea2b0f7fe65adb55d7f4004f507854db"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15546e5efbb45f0fc2291f7e202dee8623274c5d8bbfdf9c6886cc8b44a7ced3"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-encode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd983cf0a9effd76138554ead18a6de542d1af175ac12fd5e91836c5c0268082"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -5956,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
+checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5968,15 +6189,16 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a5e7810815bd295da73e4216d1dfbced3c7c7c7054d70fa5f6e4c58123fff4"
+checksum = "11f549769261561e6764218f847e500588f9a79a289de49ce92f9e26642a3574"
 dependencies = [
  "either",
  "frame-metadata",
  "parity-scale-codec",
  "scale-bits",
  "scale-decode",
+ "scale-encode",
  "scale-info",
  "serde",
  "thiserror",
@@ -6071,10 +6293,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array 0.14.6",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.5",
+ "generic-array 0.14.6",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6137,18 +6373,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6157,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -6271,6 +6507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6349,9 +6595,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2243c0405c7fbb97bac008638001daf33fe155e15f8ba28f994908b7359f5b"
+checksum = "a2600bccfb4897e030d8974a17cfb1abfb3151d1f130db4ed4af1aa3ded436e1"
 dependencies = [
  "hash-db",
  "log",
@@ -6368,11 +6614,13 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "5.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1202abd8f0b1709386c29071539d57009a8c0ea8e841418dc114461a01a3040"
+checksum = "c58a2f5386a0eb163fcb68b8057b3623cb8efa1470153aa5a9dac13907dbb95d"
 dependencies = [
+ "Inflector",
  "blake2",
+ "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -6381,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "19.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e5d5ec374fc23f4e1b87219be18e01080d8a21a2dee3b49df8befeddbf5780"
+checksum = "8cf23435a4bbd6eeec2bbbc346719ba4f3200e0ddb5f9e9f06c1724db03a8410"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6395,9 +6643,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dd56a02ca86de62dc9485d95830a5fed56fd7e4a22b13c01e62e73bc2094d2"
+checksum = "2c3d3507a803e8bc332fa290ed3015a7b51d4436ce2b836744642fc412040456"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6410,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36478fa5a773d732e35d22fa25d63f7982b2970a9048a25fcd947398ecc84e31"
+checksum = "66955fb0f32de956b981a1a466ff393f517c494c784fef56ce129562d737501a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6423,9 +6671,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7c5d4228728601b7fa86499f6cec983dc8f1135fa1bad5e86fd31cfd660e32"
+checksum = "f599badbd075bc6e56fd95cacb3ed09cd46693d56c303cd5a9838a294755076f"
 dependencies = [
  "futures",
  "log",
@@ -6442,34 +6690,50 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dbbd8b6a52634c5920f27886bb9d0d6946393108e05fb8cc710950a87ad378"
+checksum = "6490d6f21d72a11c8cdd6b4155aa43c5d2886de8ca2b6cfb2ca9594bbb9547c8"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "parity-scale-codec",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
- "sp-version",
  "thiserror",
 ]
 
 [[package]]
-name = "sp-core"
-version = "18.0.0"
+name = "sp-consensus-grandpa"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea27a1d8de728306d17502ba13127a1b1149c66e0ef348f67dafad630b50c1d"
+checksum = "ce1b051f922745ea4c5faedfe42e22bb40ddf36bdf73ae3afd2b101266e91ae0"
+dependencies = [
+ "finality-grandpa",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-core"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7789372146f8ad40d0b40fad0596cb1db5771187a258eabe19b06f00767fcbd6"
 dependencies = [
  "array-bytes",
- "base58",
  "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
+ "bs58",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -6505,11 +6769,11 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d607f7209b1b9571177fc3722a03312df03606bb65f89317ba686d5fa59d438f"
+checksum = "27449abdfbe41b473e625bce8113745e81d65777dd1d5a8462cf24137930dad8"
 dependencies = [
- "blake2",
+ "blake2b_simd",
  "byteorder",
  "digest 0.10.6",
  "sha2 0.10.6",
@@ -6520,9 +6784,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86d231d36b86d5d433c3e439e0dcaa9192861eee30158ee12c7bc009e02bdbb"
+checksum = "23061dbb10975058aaca7965991386d93d0ffa1c4316094357ce65814a0a2a1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6564,29 +6828,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-finality-grandpa"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270f72b20608f1c49bf8e9f8c523764d1d7c9910aba9f48388f78f48d934ed05"
-dependencies = [
- "finality-grandpa",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "sp-inherents"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b770e5c0a7deb764ae260cea66fcf52c74203d9af1342389b5f962bfe736f9b0"
+checksum = "802044b0af966f76f0f42c23b24349c8f6f267e3ce4165244ac01bd0a49f7bb7"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6600,9 +6845,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "19.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be5c4b33aa06da7745be99da2380a500d2f5ccf9b2df5b344d5d1c675adedaa"
+checksum = "bd3431c245992fe51b8256c838fc2e981f8d3b0afc1d1377ca7dbe0a3287a764"
 dependencies = [
  "bytes",
  "ed25519",
@@ -6611,6 +6856,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "rustversion",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -6626,9 +6872,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "20.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1772c353908e9f5333c04b22137430f3b11c9efa50ad4521e05ef5ccf349596c"
+checksum = "f5f0fc76f89011d39243e87650e3bf747ee4b19abaaeb2702988a2e0b0a7d77c"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6638,11 +6884,10 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811b1f0e8fc5b71fa359f5b4b67adedeba5dc313415e2923f8055e72c172a6ce"
+checksum = "452d079f592c97369c9ca8a5083b25f146751c6b5af10cbcacc2b24dc53fd72a"
 dependencies = [
- "async-trait",
  "futures",
  "merlin",
  "parity-scale-codec",
@@ -6666,9 +6911,9 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a045eed6f08d9993fe797c37959db2fd0251198881cf98f8f606448da5c01da2"
+checksum = "296ca314e404fa39fd6b79111e42247fc73c0537ac6f9c58acc31ed3bbedc35b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6688,9 +6933,9 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8b955c29f9f078dd19dd7e4e6b57199b4206e468454ec3d6a7330886a1dd9b"
+checksum = "82558e0876158eecd540ea3923c2fd03c07b8e5a2f228e7a6f500dbc6ff4d722"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6699,9 +6944,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "20.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02650b39d4bf5966fcd80a5b11e0cc871620952ab9be901edf1fdf1460b1ea9"
+checksum = "6220216caa67e3d931c693b06a3590dfcaa255f19bb3c3e3150f1672b8bc53f6"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6722,9 +6967,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2446ea08a1ae6dac4218b26e01c7aad6dbf47eb506f4f2b1efa821aa418a07d2"
+checksum = "ca5d0cd80200bf85b8b064238b2508b69b6146b13adf36066ec5d924825af737"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -6754,9 +6999,9 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e8aa7108c3cf19e257e1a69e4fd969e3aed8b9158580f730c6e2013497246b"
+checksum = "878c2ac2cb4e6b91d0f5184cbf1dc889b57ac193a6a57eed2f6a1cb61f8bd65e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6769,9 +7014,9 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dbd03cb38727b17b8276971f901a0e82b608c34a0f7ef24d9f8ad9b3070647"
+checksum = "04b95b340fdd272af8bbec8dbc80996931a04b89d3d1edac555dcdd447f5982d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6782,9 +7027,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f737342d849205b97e2aacd729695614d86ccb05604e34f0ffe6391d7a4ce"
+checksum = "b1e49c3bfcc8c832c34552cd8194180cc60508c6d3d9b0b9615d6b7c3e275019"
 dependencies = [
  "hash-db",
  "log",
@@ -6836,9 +7081,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e37a3f9fcd4619f4646443fd72d8dd2f4fed0b8dd905b0be2ccb9532c0ff24"
+checksum = "59b2190446f4f709596d84d29ffb8b4e80f2bb4648eff6bafb01e7b2705d2104"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6846,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0fe250ac2a1493721a1ef2a64c57f19d0d7bc44ef0dcc5615a8cb630dd483f"
+checksum = "4f0c782565ecca4c5209bd5159d4398ae2ced9dc9fbbc7ac1ce5f97eb8762b15"
 dependencies = [
  "async-trait",
  "log",
@@ -6863,13 +7108,13 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b5f3e730d26923d699766a9ca065ec39161f7af815c19acfb89c73f0402bf9"
+checksum = "58401c53c08b6ecad83acd7e14534c8bbcb3fa73e81e26685e0ac70e51b00c56"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "lazy_static",
  "memory-db",
  "nohash-hasher",
@@ -6887,9 +7132,9 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ebad12a51b507859dc2978f1a6b101b403d1544403a17a1b7c17eeed20cb0c"
+checksum = "34be5b74199bdda63e9ec48dc1e9dd605af947b76fba0c738a422a6d4ae14f47"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6917,9 +7162,9 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510bdd9ade55508e5aa05b99ab79aaa4b74a1f7476351b6ce0f3aab3b1cb2524"
+checksum = "153b7374179439e2aa783c66ed439bd86920c67bbc95d34c76390561972bc02f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -6932,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c4a96e53621ae435981fb6037d8b0be7cf32fae627780094a94ef89f194715"
+checksum = "123c661915e1bf328e21f8ecbe4e5247feba86f9149b782ea4348004547ce8ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6959,7 +7204,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.5",
 ]
 
 [[package]]
@@ -7092,9 +7347,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc-client"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bef9251ba07cc93abe2b51f6c6b3ab01064f552ecd2af0ab25389e80335051"
+checksum = "4ed6049846ab53122adc5f0ae4fa0189dce8afce3a3923886335200188a1f8af"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -7121,12 +7376,14 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.27.1"
-source = "git+https://github.com/paritytech/subxt/?rev=c9527ab#c9527abaa8fb218bd70ba32d5a6f70a34821aed1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b9c4ddefcb2d87eb18a6336f65635c29208f766d0deefaa2a1a19f7426a993"
 dependencies = [
  "base58",
  "blake2",
  "derivative",
+ "either",
  "frame-metadata",
  "futures",
  "getrandom 0.2.8",
@@ -7138,6 +7395,7 @@ dependencies = [
  "primitive-types",
  "scale-bits",
  "scale-decode",
+ "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
@@ -7153,8 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.27.1"
-source = "git+https://github.com/paritytech/subxt/?rev=c9527ab#c9527abaa8fb218bd70ba32d5a6f70a34821aed1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e924f41069e9273236398ff89662d6d336468a5d94faac812129d44547db0e7f"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -7173,8 +7432,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.27.1"
-source = "git+https://github.com/paritytech/subxt/?rev=c9527ab#c9527abaa8fb218bd70ba32d5a6f70a34821aed1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced0b043a069ee039f8700d3dfda01be156e4229c82277c305bc8e79a7dd855d"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -7184,8 +7444,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.27.1"
-source = "git+https://github.com/paritytech/subxt/?rev=c9527ab#c9527abaa8fb218bd70ba32d5a6f70a34821aed1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18be3b8f4308fe7369ee1df66ae59c2eca79de20eab57b0f41c75736e843300f"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -7269,7 +7530,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.11",
  "windows-sys 0.42.0",
 ]
 
@@ -7421,14 +7682,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -7436,18 +7696,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -7628,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.25.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3390c0409daaa6027d6681393316f4ccd3ff82e1590a1e4725014e3ae2bf1920"
+checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
@@ -7641,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "trie-root"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a36c5ca3911ed3c9a5416ee6c679042064b93fc637ded67e25f92e68d783891"
+checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
  "hash-db",
 ]
@@ -7734,9 +7994,12 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-io",
+ "sp-keystore",
+ "sp-rpc",
  "sp-runtime",
  "sp-state-machine",
  "sp-weights",
+ "substrate-rpc-client",
  "zstd",
 ]
 
@@ -8136,7 +8399,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.36.11",
  "serde",
  "sha2 0.10.6",
  "toml",
@@ -8216,7 +8479,7 @@ checksum = "d0245e8a9347017c7185a72e215218a802ff561545c242953c11ba00fccc930f"
 dependencies = [
  "object 0.29.0",
  "once_cell",
- "rustix",
+ "rustix 0.36.11",
 ]
 
 [[package]]
@@ -8247,7 +8510,7 @@ dependencies = [
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.36.11",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -8376,7 +8639,7 @@ dependencies = [
  "ccm",
  "curve25519-dalek 3.2.0",
  "der-parser 8.2.0",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "hkdf",
  "hmac 0.12.1",
  "log",
@@ -8388,11 +8651,11 @@ dependencies = [
  "rcgen 0.9.3",
  "ring",
  "rustls 0.19.1",
- "sec1",
+ "sec1 0.3.0",
  "serde",
  "sha1",
  "sha2 0.10.6",
- "signature",
+ "signature 1.6.4",
  "subtle",
  "thiserror",
  "tokio",
@@ -8510,7 +8773,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.24.3",
+ "nix",
  "rand 0.8.5",
  "thiserror",
  "tokio",
@@ -8584,7 +8847,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -8593,12 +8856,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
 ]
 
@@ -8608,7 +8871,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -8617,13 +8889,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -8631,6 +8918,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8645,6 +8938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8655,6 +8954,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8669,6 +8974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8681,10 +8992,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8697,6 +9020,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -8791,9 +9120,9 @@ dependencies = [
 
 [[package]]
 name = "yap"
-version = "0.7.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc77f52dc9e9b10d55d3f4462c3b7fc393c4f17975d641542833ab2d3bc26ef"
+checksum = "e2a7eb6d82a11e4d0b8e6bda8347169aff4ccd8235d039bba7c47482d977dcf7"
 
 [[package]]
 name = "yasna"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,10 +22,10 @@ parity-scale-codec = "3.2.2"
 tokio = { version = "1.25.0", features = ["full"] }
 
 # Substrate
-sc-executor = { version = "0.22.0" }
-sp-io = { version = "19.0.0" }
-sp-runtime = { version = "20.0.0" }
+sc-executor = { version = "0.25.0" }
+sp-io = { version = "22.0.0" }
+sp-runtime = { version = "23.0.0" }
 
-subxt = { git = "https://github.com/paritytech/subxt/", rev = "c9527ab" }
+subxt = { version = "0.28.0" }
 
 try-runtime-core = { path = "../core", features = ["cli"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Runtime testing and dry-running"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[dependencies]
+[dependencies] # todo: move to workspace
 async-trait = "0.1.57"
 clap = { version = "4.0.9", features = ["derive"], optional = true }
 hex = { version = "0.4.3", default-features = false }
@@ -22,19 +22,23 @@ serde_json = "1.0.85"
 zstd = { version = "0.11.2", default-features = false }
 
 # Substrate
-frame-remote-externalities = { version = "0.25.0" }
-frame-try-runtime = { version = "0.24.0", features = ["try-runtime"] }
+frame-remote-externalities = { version = "0.28.0" }
+frame-try-runtime = { version = "0.27.0", features = ["try-runtime"] }
 
-sc-cli = { version = "0.26.0" }
-sc-executor = { version = "0.22.0" }
+sc-cli = { version = "0.29.0" }
+sc-executor = { version = "0.25.0" }
 
-sp-api = { version = "16.0.0" }
-sp-core = { version = "18.0.0" }
+sp-api = { version = "19.0.0" }
+sp-core = { version = "20.0.0" }
 sp-externalities = { version = "0.18.0" }
-sp-io = { version = "19.0.0" }
-sp-runtime = { version = "20.0.0" }
-sp-state-machine = { version = "0.24.0" }
-sp-weights = { version = "16.0.0" }
+sp-io = { version = "22.0.0" }
+sp-keystore = { version = "0.26.0" }
+sp-runtime = { version = "23.0.0" }
+sp-rpc = { version = "19.0.0" }
+sp-state-machine = { version = "0.27.0" }
+sp-weights = { version = "19.0.0" }
+
+substrate-rpc-client = "0.26.0"
 
 [features]
 cli = [

--- a/core/src/execute_block.rs
+++ b/core/src/execute_block.rs
@@ -1,0 +1,131 @@
+use std::{fmt::Debug, str::FromStr};
+
+use frame_try_runtime::TryStateSelect;
+use parity_scale_codec::Encode;
+use sc_executor::sp_wasm_interface::HostFunctions;
+use sp_api::HeaderT;
+use sp_rpc::{list::ListOrValue, number::NumberOrHex};
+use sp_runtime::{
+    generic::SignedBlock,
+    traits::{Block as BlockT, NumberFor},
+};
+use substrate_rpc_client::{ws_client, ChainApi};
+
+use crate::{
+    build_executor, full_extensions, rpc_err_handler,
+    shared_parameters::SharedParams,
+    state::{LiveState, State},
+    state_machine_call_with_proof, LOG_TARGET,
+};
+
+pub async fn execute_block<Block, HostFns>(
+    shared: SharedParams,
+    state: State,
+    try_state_checks: TryStateSelect,
+    block_ws_uri: Option<String>,
+) -> sc_cli::Result<()>
+where
+    Block: BlockT + serde::de::DeserializeOwned,
+    Block::Hash: FromStr,
+    <Block::Hash as FromStr>::Err: Debug,
+    Block::Header: serde::de::DeserializeOwned,
+    NumberFor<Block>: FromStr,
+    <NumberFor<Block> as FromStr>::Err: Debug,
+    HostFns: HostFunctions,
+{
+    let executor = build_executor::<HostFns>(&shared);
+    let ext = state
+        .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+        .await?;
+
+    // get the block number associated with this block.
+    let block_ws_uri = resolve_block_ws_uri::<Block>(block_ws_uri.as_ref(), &state);
+    let rpc = ws_client(&block_ws_uri).await?;
+    let next_hash = next_hash_of::<Block>(&rpc, ext.block_hash).await?;
+
+    log::info!(target: LOG_TARGET, "fetching next block: {:?} ", next_hash);
+
+    let block = ChainApi::<(), Block::Hash, Block::Header, SignedBlock<Block>>::block(
+        &rpc,
+        Some(next_hash),
+    )
+    .await
+    .map_err(rpc_err_handler)?
+    .expect("header exists, block should also exist; qed")
+    .block;
+
+    // A digest item gets added when the runtime is processing the block, so we need to pop
+    // the last one to be consistent with what a gossiped block would contain.
+    let (mut header, extrinsics) = block.deconstruct();
+    header.digest_mut().pop();
+    let block = Block::new(header, extrinsics);
+
+    // for now, hardcoded for the sake of simplicity. We might customize them one day.
+    let state_root_check = false;
+    let signature_check = false;
+    let payload = (block, state_root_check, signature_check, try_state_checks).encode();
+
+    let _ = state_machine_call_with_proof::<Block, HostFns>(
+        &ext,
+        &executor,
+        "TryRuntime_execute_block",
+        &payload,
+        full_extensions(executor.clone()),
+        shared.export_proof,
+    )?;
+
+    Ok(())
+}
+
+fn resolve_block_ws_uri<Block: BlockT>(block_ws_uri: Option<&String>, state: &State) -> String
+where
+    Block::Hash: FromStr,
+    <Block::Hash as FromStr>::Err: Debug,
+{
+    match (block_ws_uri, state) {
+        (Some(block_ws_uri), State::Snap { .. }) => block_ws_uri.to_owned(),
+        (Some(block_ws_uri), State::Live { .. }) => {
+            log::error!(
+                target: LOG_TARGET,
+                "Block uri is provided while state type is live. Are you sure you know what you are doing?"
+            );
+            block_ws_uri.to_owned()
+        }
+        (None, State::Live(LiveState { uri, .. })) => uri.clone(),
+        (None, State::Snap { .. }) => {
+            panic!("either block ws uri must be provided, or state must be `Live`");
+        }
+    }
+}
+
+async fn next_hash_of<Block: BlockT>(
+    rpc: &substrate_rpc_client::WsClient,
+    hash: Block::Hash,
+) -> sc_cli::Result<Block::Hash>
+where
+    Block: BlockT + serde::de::DeserializeOwned,
+    Block::Header: serde::de::DeserializeOwned,
+{
+    let number = ChainApi::<(), Block::Hash, Block::Header, ()>::header(rpc, Some(hash))
+        .await
+        .map_err(rpc_err_handler)
+        .and_then(|maybe_header| maybe_header.ok_or("header_not_found").map(|h| *h.number()))?;
+
+    let next = number + sp_runtime::traits::One::one();
+
+    let next_hash = match ChainApi::<(), Block::Hash, Block::Header, ()>::block_hash(
+        rpc,
+        Some(ListOrValue::Value(NumberOrHex::Number(
+            next.try_into()
+                .map_err(|_| "failed to convert number to block number")?,
+        ))),
+    )
+    .await
+    .map_err(rpc_err_handler)?
+    {
+        ListOrValue::Value(t) => t.expect("value passed in; value comes out; qed"),
+        _ => unreachable!(),
+    };
+
+    Ok(next_hash)
+}

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -1,6 +1,6 @@
 use sp_runtime::StateVersion;
 
-pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
+pub(crate) fn parse_hash(block_hash: &str) -> Result<String, String> {
     let (block_hash, offset) = if let Some(block_hash) = block_hash.strip_prefix("0x") {
         (block_hash, 2)
     } else {
@@ -17,7 +17,7 @@ pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
     }
 }
 
-pub(crate) fn url(s: &str) -> Result<String, String> {
+pub(crate) fn parse_url(s: &str) -> Result<String, String> {
     if s.starts_with("ws://") || s.starts_with("wss://") {
         Ok(s.to_string())
     } else {
@@ -25,7 +25,7 @@ pub(crate) fn url(s: &str) -> Result<String, String> {
     }
 }
 
-pub(crate) fn state_version(s: &str) -> Result<StateVersion, String> {
+pub(crate) fn parse_state_version(s: &str) -> Result<StateVersion, String> {
     s.parse::<u8>()
         .map_err(|_| ())
         .and_then(StateVersion::try_from)

--- a/core/src/shared_parameters.rs
+++ b/core/src/shared_parameters.rs
@@ -4,7 +4,7 @@ use sc_cli::{WasmExecutionMethod, WasmtimeInstantiationStrategy};
 use sp_runtime::StateVersion;
 #[cfg(feature = "cli")]
 use {
-    crate::parse,
+    crate::parse::parse_state_version,
     sc_cli::{DEFAULT_WASMTIME_INSTANTIATION_STRATEGY, DEFAULT_WASM_EXECUTION_METHOD},
 };
 
@@ -64,7 +64,7 @@ pub struct SharedParams {
     /// Overwrite the `state_version`.
     ///
     /// Otherwise `remote-externalities` will automatically set the correct state version.
-    #[cfg_attr(feature = "cli", arg(long, value_parser = parse::state_version))]
+    #[cfg_attr(feature = "cli", arg(long, value_parser = parse_state_version))]
     pub overwrite_state_version: Option<StateVersion>,
 }
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -45,18 +45,18 @@ pub enum State {
 pub struct LiveState {
     /// The url to connect to.
     #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse_url))]
-    uri: String,
+    pub uri: String,
 
     /// The block hash at which to fetch the state.
     ///
     /// If non provided, then the latest finalized head is used.
     #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse_hash))]
-    at: Option<String>,
+    pub at: Option<String>,
 
     /// A pallet to scrape. Can be provided multiple times. If empty, entire chain state will
     /// be scraped.
     #[cfg_attr(feature = "cli", arg(short, long, num_args = 1..))]
-    pallet: Vec<String>,
+    pub pallet: Vec<String>,
 
     /// Fetch the child-keys as well.
     ///
@@ -64,7 +64,7 @@ pub struct LiveState {
     /// words, if you scrape the whole state the child tree data is included out of the box.
     /// Otherwise, it must be enabled explicitly using this flag.
     #[cfg_attr(feature = "cli", arg(long))]
-    child_tree: bool,
+    pub child_tree: bool,
 }
 
 impl State {

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -16,7 +16,7 @@ use sp_runtime::{
 };
 
 #[cfg(feature = "cli")]
-use crate::parse;
+use crate::parse::{parse_hash, parse_url};
 use crate::{
     ensure_try_runtime, hash_of,
     shared_parameters::{Runtime, SharedParams},
@@ -44,13 +44,13 @@ pub enum State {
 #[cfg_attr(feature = "cli", derive(clap::Args))]
 pub struct LiveState {
     /// The url to connect to.
-    #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse::url))]
+    #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse_url))]
     uri: String,
 
     /// The block hash at which to fetch the state.
     ///
     /// If non provided, then the latest finalized head is used.
-    #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse::hash))]
+    #[cfg_attr(feature = "cli", arg(short, long, value_parser = parse_hash))]
     at: Option<String>,
 
     /// A pallet to scrape. Can be provided multiple times. If empty, entire chain state will


### PR DESCRIPTION
We import second command from the Substrate repo: `execute-block`.

Local testing done:
 - built latest `polkadot` node: `cargo build --release --features try-runtime`
 - checked `on-runtime-upgrade`: `./target/release/try-runtime-cli --runtime existing on-runtime-upgrade live --uri ws://localhost:9944`
 - checked `execute-block`: `./target/release/try-runtime-cli --runtime existing execute-block live --uri ws://localhost:9944`