### PR TITLE
Improved runtime upgrade ref_time and PoV logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bytesize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10088,6 +10097,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
+ "bytesize",
  "clap",
  "frame-remote-externalities",
  "frame-try-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10041,7 +10041,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -10093,7 +10093,7 @@ dependencies = [
 
 [[package]]
 name = "try-runtime-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate's programmatic testing framework."
 edition = "2021"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # Crates.io
 async-trait = "0.1.57"
+bytesize = { version = "1.2.0", features = ["serde"] }
 clap = { version = "4.0.9", features = ["derive"], optional = true }
 hex = { version = "0.4.3", default-features = false }
 log = "0.4.17"

--- a/core/src/commands/follow_chain.rs
+++ b/core/src/commands/follow_chain.rs
@@ -17,7 +17,7 @@
 
 use std::{fmt::Debug, str::FromStr};
 
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
 use serde::{de::DeserializeOwned, Serialize};
 use sp_core::H256;
@@ -180,10 +180,7 @@ where
             continue;
         }
 
-        let (mut changes, encoded_result) = result.expect("checked to be Ok; qed");
-
-        let consumed_weight = <sp_weights::Weight as Decode>::decode(&mut &*encoded_result)
-            .map_err(|e| format!("failed to decode weight: {:?}", e))?;
+        let (mut changes, _, _) = result.expect("checked to be Ok; qed");
 
         let storage_changes = changes
             .drain_storage_changes(
@@ -203,9 +200,8 @@ where
 
         log::info!(
             target: LOG_TARGET,
-            "executed block {}, consumed weight {}, new storage root {:?}",
+            "executed block {}, new storage root {:?}",
             number,
-            consumed_weight,
             state_ext.as_backend().root(),
         );
     }

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -109,6 +109,20 @@ pub enum Action {
     FollowChain(follow_chain::Command),
 
     /// Create a new snapshot file.
+    ///
+    /// The `create-snapshot` subcommand allows creating a local snapshot of state on disk from a
+    /// remote node.
+    ///
+    /// The snapshot is saved in a format which can be loaded into memory extremely quickly,
+    /// therefore is useful when you don't want to wait for the state to download from the node
+    /// every time you run another command.
+    ///
+    /// Example of creating a snapshot of state from a remote node and using it in
+    /// `on-runtime-upgrade`:
+    ///
+    /// try-runtime create-snapshot --uri <remote-node-uri> my_state.snap
+    ///
+    /// try-runtime --runtime ./path/to/runtime.wasm on-runtime-upgrade snap --path my_state.snap
     CreateSnapshot(create_snapshot::Command),
 }
 

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -108,19 +108,20 @@ pub enum Action {
     /// tested has remained the same, otherwise block decoding might fail.
     FollowChain(follow_chain::Command),
 
-    /// Create a new snapshot file.
+    /// Create snapshot files.
     ///
-    /// The `create-snapshot` subcommand allows creating a local snapshot of state on disk from a
-    /// remote node.
+    /// The `create-snapshot` subcommand facilitates the creation of a snapshot from a node's
+    /// state. This snapshot can be loaded rapidly into memory from disk, providing an
+    /// efficient alternative to downloading state from the node for every new command
+    /// execution.
     ///
-    /// The snapshot is saved in a format which can be loaded into memory extremely quickly,
-    /// therefore is useful when you don't want to wait for the state to download from the node
-    /// every time you run another command.
+    /// **Usage**:
     ///
-    /// Example of creating a snapshot of state from a remote node and using it in
-    /// `on-runtime-upgrade`:
+    /// 1. Create a snapshot from a remote node:
     ///
     /// try-runtime create-snapshot --uri <remote-node-uri> my_state.snap
+    ///
+    /// 2. Utilize the snapshot with `on-runtime-upgrade`:
     ///
     /// try-runtime --runtime ./path/to/runtime.wasm on-runtime-upgrade snap --path my_state.snap
     CreateSnapshot(create_snapshot::Command),

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -17,14 +17,17 @@
 
 use std::{fmt::Debug, str::FromStr};
 
+use bytesize::ByteSize;
 use frame_try_runtime::UpgradeCheckSelect;
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
+use sp_core::{hexdisplay::HexDisplay, H256};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
-use sp_weights::Weight;
+use sp_state_machine::{CompactProof, StorageProof};
 
 use crate::{
-    build_executor, state::State, state_machine_call_with_proof, SharedParams, LOG_TARGET,
+    build_executor, state::State, state_machine_call_with_proof, RefTimeInfo, SharedParams,
+    LOG_TARGET,
 };
 
 /// Configuration for [`run`].
@@ -53,6 +56,90 @@ pub struct Command {
     pub checks: UpgradeCheckSelect,
 }
 
+enum WeightSafety {
+    Safe,
+    Unsafe,
+}
+
+/// Analyse the given ref_times and return if there is a potential weight safety issue.
+fn analyse_pov(proof: StorageProof, pre_root: H256) -> WeightSafety {
+    let encoded_proof_size = proof.encoded_size();
+    let compact_proof = proof
+        .clone()
+        .into_compact_proof::<sp_runtime::traits::BlakeTwo256>(pre_root)
+        .map_err(|e| {
+            log::error!(target: LOG_TARGET, "failed to generate compact proof: {:?}", e);
+            e
+        })
+        .unwrap_or(CompactProof {
+            encoded_nodes: Default::default(),
+        });
+
+    let compact_proof_size = compact_proof.encoded_size();
+    let compressed_compact_proof = zstd::stream::encode_all(&compact_proof.encode()[..], 0)
+        .map_err(|e| {
+            log::error!(
+                target: LOG_TARGET,
+                "failed to generate compressed proof: {:?}",
+                e
+            );
+            e
+        })
+        .unwrap_or_default();
+
+    let proof_nodes = proof.into_nodes();
+    log::debug!(
+        target: LOG_TARGET,
+        "Proof: 0x{}... / {} nodes",
+        HexDisplay::from(&proof_nodes.iter().flatten().cloned().take(10).collect::<Vec<_>>()),
+        proof_nodes.len()
+    );
+    log::debug!(target: LOG_TARGET, "Encoded proof size: {}", ByteSize(encoded_proof_size as u64));
+    log::debug!(target: LOG_TARGET, "Compact proof size: {}", ByteSize(compact_proof_size as u64),);
+    // if it's greater than 4MB, log a warning
+    log::info!(
+        target: LOG_TARGET,
+        "PoV (zstd-compressed compact proof) size: {}. If you are planning to submit this PoV to a relay chain, please ensure it is not greater than the maximum PoV size.",
+        ByteSize(compressed_compact_proof.len() as u64),
+    );
+    if compressed_compact_proof.len() > 4 * 1024 * 1024 {
+        log::warn!(
+            target: LOG_TARGET,
+            "PoV (zstd-compressed compact proof) size ({}) is large. \
+            Relay chains typically only accept PoVs up to 5MB in size. \
+            If you are planning to submit this PoV to a relay chain, you may want to consider \
+            reducing the number of changes in your runtime upgrade.",
+            ByteSize(compressed_compact_proof.len() as u64)
+        );
+        WeightSafety::Unsafe
+    } else {
+        WeightSafety::Safe
+    }
+}
+
+/// Analyse the given ref_times and return if there is a potential weight safety issue.
+fn analyse_ref_time(ref_time_results: RefTimeInfo) -> WeightSafety {
+    let RefTimeInfo { used, max } = ref_time_results;
+    log::info!(
+        target: LOG_TARGET,
+        "Consumed ref_time: {}s ({:.2}% of max {}s)",
+        used.as_secs_f64(),
+        used.as_secs_f64() / max.as_secs_f64() * 100.0,
+        max.as_secs_f64(),
+    );
+    if used >= max {
+        log::warn!(
+            target: LOG_TARGET,
+            "The consumed ref_time is greater than the max allowed ref_time. \
+            If this is a parachain runtime, the migration upgrade is likely too computationally \
+            expensive to be included in a single block."
+        );
+        WeightSafety::Unsafe
+    } else {
+        WeightSafety::Safe
+    }
+}
+
 // Runs the `on-runtime-upgrade` command.
 pub async fn run<Block, HostFns>(shared: SharedParams, command: Command) -> sc_cli::Result<()>
 where
@@ -69,26 +156,35 @@ where
         .to_ext::<Block, HostFns>(&shared, &executor, None, true)
         .await?;
 
-    let (_, encoded_result) = state_machine_call_with_proof::<HostFns>(
+    match command.state {
+        State::Live(_) => {
+            log::info!(target: LOG_TARGET, "🥱 Tired of slow state downloads? Create and use snapshots instead for almost instant state loading. See `try-runtime create-snapshot --help` for more.");
+        }
+        _ => {}
+    }
+
+    let method = "TryRuntime_on_runtime_upgrade";
+    let pre_root = ext.backend.root().clone();
+    let (_, proof, ref_time_results) = state_machine_call_with_proof::<HostFns>(
         &ext,
         &executor,
-        "TryRuntime_on_runtime_upgrade",
+        method,
         command.checks.encode().as_ref(),
         Default::default(), // we don't really need any extensions here.
         shared.export_proof,
     )?;
 
-    let (weight, total_weight) = <(Weight, Weight) as Decode>::decode(&mut &*encoded_result)
-        .map_err(|e| format!("failed to decode weight: {:?}", e))?;
+    let pov_safety = analyse_pov(proof, pre_root);
+    let ref_time_safety = analyse_ref_time(ref_time_results);
 
-    log::info!(
-        target: LOG_TARGET,
-        "TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = ({} ps, {} byte), total weight = ({} ps, {} byte) ({:.2} %, {:.2} %).",
-        weight.ref_time(), weight.proof_size(),
-        total_weight.ref_time(), total_weight.proof_size(),
-        (weight.ref_time() as f64 / total_weight.ref_time().max(1) as f64) * 100.0,
-        (weight.proof_size() as f64 / total_weight.proof_size().max(1) as f64) * 100.0,
-    );
+    match (pov_safety, ref_time_safety) {
+        (WeightSafety::Safe, WeightSafety::Safe) => {
+            log::info!(target: LOG_TARGET, "✅ TryRuntime_on_runtime_upgrade executed without errors or weight safety warnings.");
+        }
+        _ => {
+            log::warn!(target: LOG_TARGET, "⚠️ TryRuntime_on_runtime_upgrade executed with weight safety warnings.");
+        }
+    }
 
     Ok(())
 }

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -57,7 +57,7 @@ pub struct Command {
 }
 
 enum WeightSafety {
-    ProbabySafe,
+    ProbablySafe,
     PotentiallyUnsafe,
 }
 
@@ -111,7 +111,7 @@ fn analyse_pov(proof: StorageProof, pre_root: H256) -> WeightSafety {
         );
         WeightSafety::PotentiallyUnsafe
     } else {
-        WeightSafety::ProbabySafe
+        WeightSafety::ProbablySafe
     }
 }
 
@@ -133,7 +133,7 @@ fn analyse_ref_time(ref_time_results: RefTimeInfo) -> WeightSafety {
         );
         WeightSafety::PotentiallyUnsafe
     } else {
-        WeightSafety::ProbabySafe
+        WeightSafety::ProbablySafe
     }
 }
 
@@ -176,7 +176,7 @@ where
     let ref_time_safety = analyse_ref_time(ref_time_results);
 
     match (pov_safety, ref_time_safety) {
-        (WeightSafety::ProbabySafe, WeightSafety::ProbabySafe) => {
+        (WeightSafety::ProbablySafe, WeightSafety::ProbablySafe) => {
             log::info!(
                 target: LOG_TARGET,
                 "✅ TryRuntime_on_runtime_upgrade executed without errors or weight safety \

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -113,7 +113,7 @@ impl State {
             } => {
                 // we allow both `--snapshot-path` and `--path` for now, but `--snapshot-path` is
                 // deprecated.
-                if let Some(_) = snapshot_path {
+                if snapshot_path.is_some() {
                     log::warn!(
                         target: LOG_TARGET,
                         "`--snapshot-path` is deprecated and will be removed some time after Jan 2024. Use `--path` instead."
@@ -121,7 +121,7 @@ impl State {
                 }
                 let path = snapshot_path
                     .as_ref()
-                    .or_else(|| path.as_ref())
+                    .or(path.as_ref())
                     .ok_or_else(|| "no snapshot path provided".to_string())?;
                 Builder::<Block>::new().mode(Mode::Offline(OfflineConfig {
                     state_snapshot: SnapshotConfig::new(path),


### PR DESCRIPTION
Closes https://github.com/paritytech/try-runtime-cli/issues/13

## on-runtime-upgrade improvements 

- Improve PoV size logging
- Fix ref_time logging
- Add warnings if the runtime upgrade is likely to be overweight
- Inform users snapshots exist if they are using live state
- Allow users to disable weight warnings (useful e.g. if they are a parachain) 

## also: create-snapshot improvements
- Improve cli docs
- Deprecate `--snapshot-path` and just use `--path` (snapshot is obvious from context)