### PR TITLE
allow hashed prefix to be configured.

### DIFF
--- a/core/src/commands/follow_chain.rs
+++ b/core/src/commands/follow_chain.rs
@@ -140,6 +140,7 @@ where
                 at: Some(hex::encode(header.parent_hash().encode())),
                 pallet: vec![],
                 child_tree: true,
+                hashed_prefixes: vec![],
             });
             let ext = state
                 .to_ext::<Block, HostFns>(&shared, &executor, None, true)

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -62,7 +62,7 @@ pub struct LiveState {
     /// A pallet to scrape. Can be provided multiple times. If empty, entire chain state will
     /// be scraped.
     ///
-    /// This is equivalent to passing the `xx_hash_64(pallet)` to `prefix`.
+    /// This is equivalent to passing `xx_hash_64(pallet)` to `--hashed_prefixes`.
     #[arg(short, long, num_args = 1..)]
     pub pallet: Vec<String>,
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -149,7 +149,7 @@ impl State {
                     .map(|p_str| {
                         hex::decode(p_str).map_err(|e| {
                             format!(
-                                "error while decoding prefix {:?} as hex string: {:?}",
+                                "Error decoding `hashed_prefixes` hex string entry '{:?}' to bytes: {:?}",
                                 p_str, e
                             )
                         })

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -145,7 +145,7 @@ impl State {
                     None => None,
                 };
                 let hashed_prefixes = hashed_prefixes
-                    .into_iter()
+                    .iter()
                     .map(|p_str| {
                         hex::decode(p_str).map_err(|e| {
                             format!(

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -66,7 +66,7 @@ pub struct LiveState {
     #[arg(short, long, num_args = 1..)]
     pub pallet: Vec<String>,
 
-    /// A hashed prefix to scrape.
+    /// Storage entry key prefixes to scrape and inject into the test externalities. Pass as 0x prefixed hex strings. By default, all keys are scraped and included.
     #[arg(long = "prefix", value_parser = parse::hash, num_args = 1..)]
     pub hashed_prefixes: Vec<String>,
 


### PR DESCRIPTION
Exposes the ability to download just a specific prefix from `remote-ext` to `try-runtime-cli`. 