### PR TITLE
Warn if user runs `on-runtime-upgrade` with a spec version not gt on-chain spec version

### DIFF
--- a/core/src/commands/create_snapshot.rs
+++ b/core/src/commands/create_snapshot.rs
@@ -76,7 +76,7 @@ where
 
     let executor = build_executor::<HostFns>(&shared);
     let _ = State::Live(command.from)
-        .to_ext::<Block, HostFns>(&shared, &executor, Some(path.into()), false)
+        .to_ext::<Block, HostFns>(&shared, &executor, Some(path.into()), false, false)
         .await?;
 
     Ok(())

--- a/core/src/commands/execute_block.rs
+++ b/core/src/commands/execute_block.rs
@@ -97,7 +97,7 @@ where
     let executor = build_executor::<HostFns>(&shared);
     let ext = command
         .state
-        .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+        .to_ext::<Block, HostFns>(&shared, &executor, None, true, false)
         .await?;
 
     // get the block number associated with this block.

--- a/core/src/commands/fast_forward.rs
+++ b/core/src/commands/fast_forward.rs
@@ -234,7 +234,7 @@ where
     let executor = build_executor::<HostFns>(&shared);
     let ext = command
         .state
-        .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+        .to_ext::<Block, HostFns>(&shared, &executor, None, true, false)
         .await?;
 
     if command.run_migrations {

--- a/core/src/commands/follow_chain.rs
+++ b/core/src/commands/follow_chain.rs
@@ -143,7 +143,7 @@ where
                 hashed_prefixes: vec![],
             });
             let ext = state
-                .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+                .to_ext::<Block, HostFns>(&shared, &executor, None, true, false)
                 .await?;
             maybe_state_ext = Some(ext);
         }

--- a/core/src/commands/offchain_worker.rs
+++ b/core/src/commands/offchain_worker.rs
@@ -78,7 +78,7 @@ where
     // we first build the externalities with the remote code.
     let ext = command
         .state
-        .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+        .to_ext::<Block, HostFns>(&shared, &executor, None, true, false)
         .await?;
 
     let header_ws_uri = command.header_ws_uri();

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -76,7 +76,7 @@ where
     let executor = build_executor(&shared);
     let ext = command
         .state
-        .to_ext::<Block, HostFns>(&shared, &executor, None, true)
+        .to_ext::<Block, HostFns>(&shared, &executor, None, true, true)
         .await?;
 
     if let State::Live(_) = command.state {

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -66,7 +66,8 @@ pub struct LiveState {
     #[arg(short, long, num_args = 1..)]
     pub pallet: Vec<String>,
 
-    /// Storage entry key prefixes to scrape and inject into the test externalities. Pass as 0x prefixed hex strings. By default, all keys are scraped and included.
+    /// Storage entry key prefixes to scrape and inject into the test externalities. Pass as 0x
+    /// prefixed hex strings. By default, all keys are scraped and included.
     #[arg(long = "prefix", value_parser = parse::hash, num_args = 1..)]
     pub hashed_prefixes: Vec<String>,
 
@@ -107,6 +108,7 @@ impl State {
         executor: &WasmExecutor<HostFns>,
         state_snapshot: Option<SnapshotConfig>,
         try_runtime_check: bool,
+        spec_version_check: bool,
     ) -> sc_cli::Result<RemoteExternalities<Block>>
     where
         Block::Header: DeserializeOwned,
@@ -252,6 +254,13 @@ impl State {
 
             if new_version.spec_name != old_version.spec_name {
                 return Err("Spec names must match.".into());
+            }
+
+            if spec_version_check && new_version.spec_version <= old_version.spec_version {
+                log::warn!(
+                    target: LOG_TARGET,
+                    "New runtime spec version is not greater than the on-chain runtime spec version. Don't forget to increment the spec version if you intend to use the new code in a runtime upgrade."
+                );
             }
         }
 


### PR DESCRIPTION
Closes #35 

A parachain team was stung by misconfiguring their spec version, unsure why their upgrade wasn't executing.

Add a warning to prevent this.