### PR TITLE
Use `stable` toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,14 +1,8 @@
 [toolchain]
 channel = "stable"
 components = [
-	"cargo",
-	"clippy",
-	"rust-analyzer",
 	"rust-src",
-	"rust-std",
 	"rustc-dev",
-	"rustc",
-	"rustfmt",
 ]
 targets = [ "wasm32-unknown-unknown" ]
-profile = "minimal"
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.1"
+channel = "stable"
 components = [
 	"cargo",
 	"clippy",


### PR DESCRIPTION
https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

Rather than demand a version, we can allow for the latest stable. Perhaps a bit more prone to breaking on changes but then users are not forced to use this version... I hope we don't _require_ this version :crossed_fingers:

https://rust-lang.github.io/rustup/concepts/profiles.html

we also can be less demanding in what profile we need I think.