### PR TITLE
Exit with non-zero code when there're weight warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11262,7 +11262,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "env_logger",
@@ -11314,7 +11314,7 @@ dependencies = [
 
 [[package]]
 name = "try-runtime-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate's programmatic testing framework."
 edition = "2021"

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -144,6 +144,8 @@ where
         _ => {
             log::warn!(target: LOG_TARGET, "⚠️  TryRuntime_on_runtime_upgrade executed \
             successfully but with weight safety warnings.");
+            // Exit with a non-zero exit code to indicate that the runtime upgrade may not be safe.
+            std::process::exit(1);
         }
     }
 


### PR DESCRIPTION
Helpful to make things like CI jobs fail.