### PR TITLE
Update CI Rust checks

### DIFF
--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -10,57 +10,44 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-jobs:
-  rust-fmt:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt
-      - uses: actions-rust-lang/rustfmt@v1
+env:
+  RUST_BACKTRACE: 1
+  TOOLCHAIN_LINT: nightly
 
-  clippy-lint:
+jobs:
+  lint:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Rust ${{ env.TOOLCHAIN_LINT }}
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          components: clippy
+          toolchain: ${{ env.TOOLCHAIN_LINT }}
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+      - name: cargo fmt
+        run: cargo +nightly fmt --all -- --check
       - name: Install deps for musl build
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler musl-tools clang build-essential curl llvm-dev libclang-dev linux-headers-generic libsnappy-dev liblz4-dev libzstd-dev libgflags-dev zlib1g-dev libbz2-dev
-          sudo ln -s /usr/bin/g++ /usr/bin/musl-g++      
-      - name: Clippy
+          sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
+      - name: cargo clippy
         uses: actions-rs-plus/clippy-check@v2
         with:
-          toolchain: stable
-          args: --all-targets --all-features
+          # toolchain: ${{ env.TOOLCHAIN_LINT }}
+          args: --all-targets --all-features -- --deny warnings
 
-  rust-tests:
-    runs-on: ubuntu-20.04
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        toolchain: [stable]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: "3.6.1"
-
-      - name: Add wasm32-unknown-unknown target
-        run: rustup target add wasm32-unknown-unknown
-
+      - uses: actions/checkout@v4
       - name: Check disk space
         run: df . -h
-
       - name: Free disk space
         run: |
           sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
@@ -87,14 +74,20 @@ jobs:
             sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
             sudo apt-get autoremove -y >/dev/null 2>&1
             sudo apt-get autoclean -y >/dev/null 2>&1
-
       - name: Check disk space
         run: df . -h
-  
-      - name: cargo build binary required for test
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: wasm32-unknown-unknown
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.6.1"
+      - name: build try-runtime-cli
+        # this is required for testing
         # build --release or the execution time of the test is too long
         run: cargo build --release -p try-runtime-cli
-
       - name: cargo test
-        # build --release or the execution time of the test is too long
         run: cargo test --release

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -12,11 +12,12 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  TOOLCHAIN_LINT: nightly
+  # pin nightly to avoid constantly throwing out cache
+  TOOLCHAIN_LINT: nightly-2023-11-13
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust ${{ env.TOOLCHAIN_LINT }}
@@ -26,8 +27,10 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: lint-v0
       - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +${{ env.TOOLCHAIN_LINT }} fmt --all -- --check
       - name: Install deps for musl build
         run: |
           sudo apt-get update
@@ -37,12 +40,12 @@ jobs:
         uses: actions-rs-plus/clippy-check@v2
         with:
           toolchain: ${{ env.TOOLCHAIN_LINT }}
-          args: --all-targets --all-features --locked -- --deny warnings
+          args: --all-targets --all-features --locked --no-deps -- --deny warnings
 
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         toolchain: [stable]
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,36 +56,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Check disk space
-        run: df . -h
-      - name: Free disk space
-        run: |
-          sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
-          sudo rm -rf \
-            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-            /usr/lib/jvm || true
-          sudo apt install aptitude -y >/dev/null 2>&1
-          sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
-            esl-erlang firefox gfortran-8 gfortran-9 google-chrome-stable \
-            google-cloud-sdk imagemagick \
-            libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
-            mercurial apt-transport-https mono-complete libmysqlclient \
-            unixodbc-dev yarn chrpath libssl-dev libxft-dev \
-            libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
-            snmp pollinate libpq-dev postgresql-client powershell ruby-full \
-            sphinxsearch subversion mongodb-org azure-cli microsoft-edge-stable \
-            -y -f >/dev/null 2>&1
-          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1
-          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
-          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1
-          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
-          sudo apt-get autoremove -y >/dev/null 2>&1
-          sudo apt-get autoclean -y >/dev/null 2>&1
-      - name: Check disk space
-        run: df . -h
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -93,3 +66,5 @@ jobs:
         run: cargo build --release -p try-runtime-cli
       - name: cargo test
         run: cargo test --release
+      - name: Check disk space
+        run: df . -h

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -25,6 +25,7 @@ jobs:
           toolchain: ${{ env.TOOLCHAIN_LINT }}
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
       - name: cargo fmt
         run: cargo +nightly fmt --all -- --check
       - name: Install deps for musl build
@@ -36,7 +37,7 @@ jobs:
         uses: actions-rs-plus/clippy-check@v2
         with:
           toolchain: ${{ env.TOOLCHAIN_LINT }}
-          args: --all-targets --all-features -- --deny warnings
+          args: --all-targets --all-features --locked -- --deny warnings
 
   test:
     strategy:
@@ -46,6 +47,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - name: Check disk space
         run: df . -h
       - name: Free disk space
@@ -59,28 +66,23 @@ jobs:
           sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
             esl-erlang firefox gfortran-8 gfortran-9 google-chrome-stable \
             google-cloud-sdk imagemagick \
-              libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
-              mercurial apt-transport-https mono-complete libmysqlclient \
-              unixodbc-dev yarn chrpath libssl-dev libxft-dev \
-              libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
-              snmp pollinate libpq-dev postgresql-client powershell ruby-full \
-              sphinxsearch subversion mongodb-org azure-cli microsoft-edge-stable \
-              -y -f >/dev/null 2>&1
-            sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1
-            sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-            sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-            sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
-            sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1
-            sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
-            sudo apt-get autoremove -y >/dev/null 2>&1
-            sudo apt-get autoclean -y >/dev/null 2>&1
+            libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
+            mercurial apt-transport-https mono-complete libmysqlclient \
+            unixodbc-dev yarn chrpath libssl-dev libxft-dev \
+            libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+            snmp pollinate libpq-dev postgresql-client powershell ruby-full \
+            sphinxsearch subversion mongodb-org azure-cli microsoft-edge-stable \
+            -y -f >/dev/null 2>&1
+          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1
+          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
       - name: Check disk space
         run: df . -h
-      - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          targets: wasm32-unknown-unknown
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: cargo clippy
         uses: actions-rs-plus/clippy-check@v2
         with:
-          # toolchain: ${{ env.TOOLCHAIN_LINT }}
+          toolchain: ${{ env.TOOLCHAIN_LINT }}
           args: --all-targets --all-features -- --deny warnings
 
   test:


### PR DESCRIPTION
helps #19

summary
* use `dtolnay/rust-toolchain` instead
* use nightly for both fmt and clippy, for the latest features
* `clippy -- --deny warnings` (let me know if this isn’t what you want)
* use matrix for testing (easier to add more targets)

I combined fmt and clippy into one job so that we don’t have to repeat the checkout-install ceremony. Also coz by definition linting does address stylistic errors. :)) But if you don’t like it, I could split them, no problem.

Curious, is there a reason why we’re using `ubuntu-20.04` instead of `ubuntu-latest`?