### PR TITLE
Add flag to see storage diff if idemptotent check fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11080,7 +11080,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -11133,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "try-runtime-core"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
 dependencies = [
  "anstyle",
- "bstr",
+ "bstr 1.9.0",
  "doc-comment",
  "predicates 3.1.0",
  "predicates-core",
@@ -963,6 +963,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2927,7 +2938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 1.9.0",
  "log",
  "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
@@ -9088,6 +9099,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+dependencies = [
+ "bstr 0.2.17",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11122,6 +11153,7 @@ dependencies = [
  "sc-service",
  "serde",
  "serde_json",
+ "similar-asserts",
  "sp-api",
  "sp-consensus-aura",
  "sp-consensus-babe",
@@ -11210,6 +11242,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["cli", "core"]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate's programmatic testing framework."
 edition = "2021"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,7 @@ sp-weights = { workspace = true }
 
 substrate-rpc-client = { workspace = true }
 paris = "1.5.15"
+similar-asserts = "1.5.0"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -212,7 +212,7 @@ where
                             log::info!("Changed storage keys:");
                             let changes_after =
                                 collect_storage_changes_as_hex::<Block>(&overlayed_changes);
-                            overlayed_changes.rollback_transaction().unwrap();
+                            overlayed_changes.rollback_transaction().expect("Migrations must not rollback transactions that they did not open");
                             let changes_before =
                                 collect_storage_changes_as_hex::<Block>(&overlayed_changes);
 

--- a/core/src/commands/on_runtime_upgrade.rs
+++ b/core/src/commands/on_runtime_upgrade.rs
@@ -212,7 +212,9 @@ where
                             log::info!("Changed storage keys:");
                             let changes_after =
                                 collect_storage_changes_as_hex::<Block>(&overlayed_changes);
-                            overlayed_changes.rollback_transaction().expect("Migrations must not rollback transactions that they did not open");
+                            overlayed_changes.rollback_transaction().expect(
+                                "Migrations must not rollback transactions that they did not open",
+                            );
                             let changes_before =
                                 collect_storage_changes_as_hex::<Block>(&overlayed_changes);
 


### PR DESCRIPTION
When the idempotent migration check fails, users see this unhelpful error message:

```
❌ Migrations are not idempotent. Selectively remove migrations from Executive until you find the culprit.
```

This PR implements a flag to enable printing the differences in storage. It is disabled by default because users can ignore the "idempotent" warning if they want to. If the flag is disabled there is a log that suggests enabling it, improving the old message.

![Captura desde 2024-02-20 13-59-48](https://github.com/paritytech/try-runtime-cli/assets/44604217/1ae51887-6d26-411a-8874-23924b5cb536)
