### PR TITLE
fix: `execute-block` handle no explicit `--at`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11080,7 +11080,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "env_logger",
@@ -11133,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "try-runtime-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["cli", "core"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate's programmatic testing framework."
 edition = "2021"

--- a/core/src/commands/execute_block.rs
+++ b/core/src/commands/execute_block.rs
@@ -100,7 +100,7 @@ where
     let live_state = match command.state {
         State::Live(live_state) => {
             // If no --at is provided, get the latest block to replay
-            if let Some(_) = live_state.at {
+            if live_state.at.is_some() {
                 live_state
             } else {
                 let header =

--- a/core/tests/execute_block.rs
+++ b/core/tests/execute_block.rs
@@ -28,7 +28,6 @@ use tokio::process::Command;
 #[tokio::test]
 async fn execute_block_works() {
     let port = 45789;
-    let ws_url = format!("ws://localhost:{}", port);
 
     // Spawn a dev node.
     let _ = std::thread::spawn(move || {
@@ -46,7 +45,10 @@ async fn execute_block_works() {
     // Wait some time to ensure the node is warmed up.
     std::thread::sleep(Duration::from_secs(90));
 
+    // Test passing --at
     common::run_with_timeout(Duration::from_secs(60), async move {
+        let ws_url = format!("ws://localhost:{}", port);
+
         fn execute_block(ws_url: &str, at: Hash) -> tokio::process::Child {
             Command::new(cargo_bin("try-runtime"))
                 .stdout(std::process::Stdio::piped())
@@ -69,6 +71,44 @@ async fn execute_block_works() {
         // The execute-block command is actually executing the next block.
         let expected_output = format!(r#".*Block #{} successfully executed"#, block_number);
         let re = Regex::new(expected_output.as_str()).unwrap();
+        let matched =
+            common::wait_for_stream_pattern_match(block_execution.stderr.take().unwrap(), re).await;
+
+        // Assert that the block-execution process has executed the expected block.
+        assert!(matched.is_ok());
+
+        // Assert that the block-execution exited succesfully
+        assert!(block_execution
+            .wait_with_output()
+            .await
+            .unwrap()
+            .status
+            .success());
+    })
+    .await;
+
+    // Test not passing --at
+    common::run_with_timeout(Duration::from_secs(60), async move {
+        let ws_url = format!("ws://localhost:{}", port);
+
+        fn execute_block(ws_url: &str) -> tokio::process::Child {
+            Command::new(cargo_bin("try-runtime"))
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .arg("--runtime=existing")
+                .args(["execute-block"])
+                .args(["live", format!("--uri={}", ws_url).as_str()])
+                .kill_on_drop(true)
+                .spawn()
+                .unwrap()
+        }
+
+        // Try to execute the block.
+        let mut block_execution = execute_block(&ws_url);
+
+        // The execute-block command is actually executing the next block.
+        let expected_output = r".*Block #(\d+) successfully executed";
+        let re = Regex::new(expected_output).unwrap();
         let matched =
             common::wait_for_stream_pattern_match(block_execution.stderr.take().unwrap(), re).await;
 

--- a/core/tests/execute_block.rs
+++ b/core/tests/execute_block.rs
@@ -105,14 +105,12 @@ async fn execute_block_works() {
 
         // Try to execute the block.
         let mut block_execution = execute_block(&ws_url);
-
-        // The execute-block command is actually executing the next block.
         let expected_output = r".*Block #(\d+) successfully executed";
         let re = Regex::new(expected_output).unwrap();
         let matched =
             common::wait_for_stream_pattern_match(block_execution.stderr.take().unwrap(), re).await;
 
-        // Assert that the block-execution process has executed the expected block.
+        // Assert that the block-execution process has executed a block.
         assert!(matched.is_ok());
 
         // Assert that the block-execution exited succesfully


### PR DESCRIPTION
`execute-block` currently panics during block execution if `--at` is not passed, due to trying to execute a block that doesn't match current state.