### PR TITLE
Update 'time' in Cargo.lock to resovle build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5436,6 +5436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12053,12 +12059,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -12073,10 +12080,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -20,10 +20,12 @@
 //! Substrate's programmatic testing framework.
 //!
 //! > As the name suggests, `try-runtime` is a detailed testing framework that gives you a lot of
-//!> control over what is being executed in which environment. It is recommended that user's first
-//!> familiarize themselves with substrate in depth, particularly the execution model. It is critical
-//!> to deeply understand how the wasm/client/runtime interactions, and the runtime apis work in the
-//!> substrate runtime, before commencing to working with `try-runtime`.
+//! > control over what is being executed in which environment. It is recommended that user's first
+//! > familiarize themselves with substrate in depth, particularly the execution model. It is
+//! > critical
+//! > to deeply understand how the wasm/client/runtime interactions, and the runtime apis work in
+//! > the
+//! > substrate runtime, before commencing to working with `try-runtime`.
 //!
 //! #### Resources
 //!
@@ -176,9 +178,9 @@
 //!
 //! For the following examples, we assume the existence of the following:
 //!
-//! 1. a substrate node compiled with `--features try-runtime`, called `substrate`. This will be
-//!    the running node that you connect to, and provide a wasm blob that has try-runtime
-//!    functionality enabled.
+//! 1. a substrate node compiled with `--features try-runtime`, called `substrate`. This will be the
+//!    running node that you connect to, and provide a wasm blob that has try-runtime functionality
+//!    enabled.
 //! 2. the `try-runtime` CLI binary on your path.
 //!
 //! ```bash
@@ -200,8 +202,8 @@
 //! ```
 //!
 //! * Same as the previous example, but run it at specific block number's state and using the live
-//!   polkadot network. This means that this block hash's state should not yet have been pruned by the
-//!   node running at `rpc.polkadot.io`.
+//!   polkadot network. This means that this block hash's state should not yet have been pruned by
+//!   the node running at `rpc.polkadot.io`.
 //!
 //! ```bash
 //! try-runtime \

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -20,10 +20,10 @@
 //! Substrate's programmatic testing framework.
 //!
 //! > As the name suggests, `try-runtime` is a detailed testing framework that gives you a lot of
-//! control over what is being executed in which environment. It is recommended that user's first
-//! familiarize themselves with substrate in depth, particularly the execution model. It is critical
-//! to deeply understand how the wasm/client/runtime interactions, and the runtime apis work in the
-//! substrate runtime, before commencing to working with `try-runtime`.
+//!> control over what is being executed in which environment. It is recommended that user's first
+//!> familiarize themselves with substrate in depth, particularly the execution model. It is critical
+//!> to deeply understand how the wasm/client/runtime interactions, and the runtime apis work in the
+//!> substrate runtime, before commencing to working with `try-runtime`.
 //!
 //! #### Resources
 //!
@@ -177,8 +177,8 @@
 //! For the following examples, we assume the existence of the following:
 //!
 //! 1. a substrate node compiled with `--features try-runtime`, called `substrate`. This will be
-//! the running node that you connect to, and provide a wasm blob that has try-runtime
-//! functionality enabled.
+//!    the running node that you connect to, and provide a wasm blob that has try-runtime
+//!    functionality enabled.
 //! 2. the `try-runtime` CLI binary on your path.
 //!
 //! ```bash
@@ -200,8 +200,8 @@
 //! ```
 //!
 //! * Same as the previous example, but run it at specific block number's state and using the live
-//! polkadot network. This means that this block hash's state should not yet have been pruned by the
-//! node running at `rpc.polkadot.io`.
+//!   polkadot network. This means that this block hash's state should not yet have been pruned by the
+//!   node running at `rpc.polkadot.io`.
 //!
 //! ```bash
 //! try-runtime \


### PR DESCRIPTION
I tried to run this tool using the command in the docs (https://paritytech.github.io/try-runtime-cli/try_runtime/#installation) and ran into:

```
   Compiling tokio-stream v0.1.14
   Compiling inout v0.1.3
   Compiling polkavm-assembler v0.9.0
   Compiling polkavm-common v0.9.0
   Compiling hex-literal v0.4.1
   Compiling prometheus v0.13.3
   Compiling heck v0.5.0
   Compiling time v0.3.31
   Compiling hyper v0.14.28
   Compiling polkavm v0.9.3
   Compiling cipher v0.4.4
   Compiling prost v0.12.4
   Compiling prost-derive v0.11.9
error[E0282]: type annotations needed for `Box<_>`
  --> /Users/jameswilson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.31/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

   Compiling wasm-instrument v0.4.0
For more information about this error, try `rustc --explain E0282`.
```

Doing a global `cargo update` led to an inability to resolve dependencies, but `cargo update time` specifically seems to resovle the build issue for me!