### PR TITLE
Add info on calling pre & post checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ cargo build --features try-runtime --release && cp target/release/substrate .
 try-runtime \
     --runtime /path-to-substrate/target/release/wbuild/my-runtime.wasm \
     on-runtime-upgrade \
+    # if you'd like pre_upgrade & post_upgrade to run
+    --disable-mbm-checks \
     live --uri ws://localhost:9999
 ```
 


### PR DESCRIPTION
While writing and testing my first migration, it took me a while to realize the hooks for UncheckedOnRuntimeUpgrade::pre_upgrade/post_upgrade weren't running due to the --disable-mbm-checks flag not being set.

This PR adds a bit of extra information to the readme that would have been helpful.

See code - [flag logic](https://github.com/paritytech/try-runtime-cli/blob/b45be7dfce89fd881be27171d3ea114ef19d832c/core/src/commands/on_runtime_upgrade/mod.rs#L135)
Introduced in #90 
@liamaharon 