### PR TITLE
Bump polkadot-sdk to master @ `e1c5425b23f1`

### DIFF
--- a/.github/workflows/build-release-binaries.yaml
+++ b/.github/workflows/build-release-binaries.yaml
@@ -1,6 +1,7 @@
 name: Build and Attach Binaries to Release
 
 env:
+  # must match polkadot-sdk's CI toolchain (see .github/env in polkadot-sdk)
   TOOLCHAIN_STABLE: "1.93.0"
 
 on:

--- a/.github/workflows/build-release-binaries.yaml
+++ b/.github/workflows/build-release-binaries.yaml
@@ -1,5 +1,8 @@
 name: Build and Attach Binaries to Release
 
+env:
+  TOOLCHAIN_STABLE: "1.93.0"
+
 on:
   release:
     types:
@@ -35,7 +38,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           override: true
 
       - name: Add apple target

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -14,15 +14,18 @@ env:
   RUST_BACKTRACE: 1
   # pin nightly to avoid constantly throwing out cache
   TOOLCHAIN_FMT: nightly-2026-01-01
+  # must match polkadot-sdk's CI toolchain (see .github/env in polkadot-sdk)
+  TOOLCHAIN_STABLE: "1.93.0"
 
 jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust stable
+      - name: Install Rust ${{ env.TOOLCHAIN_STABLE }}
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
@@ -58,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust stable
+      - name: Install Rust ${{ env.TOOLCHAIN_STABLE }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy, rust-src
       - uses: Swatinem/rust-cache@v2
@@ -75,23 +78,22 @@ jobs:
       - name: cargo clippy
         uses: actions-rs-plus/clippy-check@v2
         with:
-          toolchain: stable
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           args: --all-targets --all-features --locked --no-deps -- --deny warnings
 
   test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        toolchain: [stable]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: "-Cdebug-assertions=y"
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ matrix.toolchain }}
+      - name: Install Rust ${{ env.TOOLCHAIN_STABLE }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install Protoc

--- a/.github/workflows/rust-docs.yaml
+++ b/.github/workflows/rust-docs.yaml
@@ -1,6 +1,7 @@
 name: Update rust docs
 
 env:
+  # must match polkadot-sdk's CI toolchain (see .github/env in polkadot-sdk)
   TOOLCHAIN_STABLE: "1.93.0"
 
 on:

--- a/.github/workflows/rust-docs.yaml
+++ b/.github/workflows/rust-docs.yaml
@@ -1,5 +1,8 @@
 name: Update rust docs
 
+env:
+  TOOLCHAIN_STABLE: "1.93.0"
+
 on:
   push:
     branches:
@@ -27,10 +30,10 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.TOOLCHAIN_STABLE }}
           targets: wasm32-unknown-unknown
           components: rust-src
-        
+
       - name: Check if the README is up to date.
         run: |
           cargo install cargo-rdme --locked -q

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,6 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli 0.31.1",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
@@ -42,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -54,7 +45,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -112,9 +103,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-consensus"
-version = "1.4.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3a590d13de3944675987394715f37537b50b856e3b23a0e66e97d963edbf38"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -139,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4087016b0896051dd3d03e0bedda2f4d4d1689af8addc8450288c63a9e5f68"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -152,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f5707b958927176265e8a58627fc6195e5dfa5c55689396e68b241b3a72e6"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -163,7 +154,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -206,14 +197,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.4.3"
+name = "alloy-eip7928"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09535cbc646b0e0c6fcc12b7597eaed12cf86dff4c4fba9507a61e71b94f30eb"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -225,14 +231,13 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e3cf01219c966f95a460c95f1d4c30e12f6c18150c21a30b768af2a2a29142"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -242,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -252,27 +257,27 @@ dependencies = [
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
+ "secp256k1 0.31.1",
  "serde",
- "sha3",
- "tiny-keccak",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec 0.7.6",
@@ -281,20 +286,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.4.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed8531cae8d21ee1c6571d0995f8c9f0652a6ef6452fde369283edea6ab7138"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -303,41 +308,41 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09eb18ce0df92b4277291bbaa0ed70545d78b02948df756bbd3d6214bf39a218"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d9fa2daf21f59aa546d549943f10b5cce1ae59986774019fbedae834ffe01b"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "sha3 0.11.0",
+ "syn 2.0.117",
  "syn-solidity",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9396007fe69c26ee118a19f4dee1f5d1d6be186ea75b3881adf16d87f8444686"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -345,25 +350,25 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67a0b0dcebe14244fc92002cd8d96ecbf65db4639d479f5fcd5805755a4c27"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aeea64f09a7483bdcd4193634c7e5cf9fd7775ee767585270cd8ce2d69dc95"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -373,30 +378,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428aa0f0e0658ff091f8f667c406e034b431cb10abd39de4f507520968acc499"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec 0.7.6",
  "derive_more 2.1.1",
  "nybbles",
  "serde",
  "smallvec",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.4.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -416,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -431,15 +436,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -466,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -490,7 +495,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -523,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-377-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47f3bb6e4ef3c0edb795769fc11469767ce807ed1ccdc979ab101aea2dbf4b5"
+checksum = "07208c7ea9e7abfe8fb01e190eba611f6e7c3cdbdef4a5473c9297d396495d1b"
 dependencies = [
  "ark-bls12-377 0.5.0",
  "ark-ec 0.5.0",
@@ -560,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1dbb23366825700828d373d5fc9c07b7f92253ffed47ab455003b7590d786d"
+checksum = "8a83d59f25570c846b9cfc430539a150e9634c9db6949f87b12f3cbc53149b17"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-ec 0.5.0",
@@ -598,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-761-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e1216f968e21c72fdaba53dbc9e547a8a60cc87b1dc74ac589727e906f9297"
+checksum = "60f7fc87dfb5699c1c5a12e8d4f13564c174a5224b5702002587ca67205a9ca7"
 dependencies = [
  "ark-bw6-761",
  "ark-ec 0.5.0",
@@ -662,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-377-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05093aa26f017411708e1271047852cc5f58686336f1f1a56fb2df747c3e173a"
+checksum = "93170025f4679342661d00f27c9a1586ccf053d29ad78b072d5be11649cae02c"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ed-on-bls12-377",
@@ -687,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-381-bandersnatch-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6dce0c47def6f25cf01022acded4f32732f577187dfcd1268510093ef16ea6"
+checksum = "ee7e1fb880811e22d4fc8ffe83eaa260e39a4deb0f345dcc8ffb663d3e034e7a"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -784,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -822,20 +827,45 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ark-models-ext"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff772c552d00e9c092eab0608632342c553abbf6bca984008b55100a9a78a3a6"
+checksum = "6294fd6ddc4996910adf2a9d3b56e3aa6a1f605ea315952169d2ddebc304dc4c"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "derivative",
+]
+
+[[package]]
+name = "ark-pallas"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c676d42c65f0b2d334fc0ae72a422de2e62ed75beb3022050c0e8a81f6ccc0f"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-pallas-ext"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6906648fb42b7c83fc40ea43b12fbf75b704532057d71a467a25ec4afc239b6"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-models-ext",
+ "ark-pallas",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -965,7 +995,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1010,7 +1040,33 @@ dependencies = [
  "ark-std 0.5.0",
  "digest 0.10.7",
  "rand_core 0.6.4",
- "sha3",
+ "sha3 0.10.9",
+]
+
+[[package]]
+name = "ark-vesta"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a6d658e5e7380af710828550b2dc2c7b033c9f3103d2690711cb07d5a62df6"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-pallas",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-vesta-ext"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dfabb2b731180273184366ebf57b1793600889e9c7b548916433dd19fb8932"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-models-ext",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "ark-vesta",
 ]
 
 [[package]]
@@ -1029,7 +1085,26 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "sha2 0.10.9",
- "w3f-ring-proof",
+ "w3f-ring-proof 0.0.2",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-vrf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69f34cb5a7d5d4627792c7a6343508becc19deab59a87ef73367cc112dfd02c"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "digest 0.10.7",
+ "generic-array 0.14.7",
+ "sha2 0.10.9",
+ "w3f-ring-proof 0.0.8",
  "zeroize",
 ]
 
@@ -1069,9 +1144,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -1091,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
@@ -1113,8 +1185,8 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -1125,8 +1197,8 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -1137,14 +1209,14 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "6efbf8007cf161459a3f7b35eafe11fee402cd93f6bf3df9b6ad6668756634c3"
 dependencies = [
  "anstyle",
  "bstr",
@@ -1164,7 +1236,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -1195,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1245,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -1281,7 +1353,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -1323,14 +1395,14 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -1338,7 +1410,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -1358,7 +1430,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1428,14 +1500,14 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "az"
@@ -1449,7 +1521,7 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.25.1",
+ "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -1501,7 +1573,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "hash-db",
  "log",
@@ -1514,16 +1586,16 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.114",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1573,15 +1645,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -1595,9 +1667,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -1656,16 +1728,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1684,6 +1756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1713,25 +1794,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases 0.2.1",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1771,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1788,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1804,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1821,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1838,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1856,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1879,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1899,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1916,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1928,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1947,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1989,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2034,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.14",
  "serde",
 ]
 
@@ -2049,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
@@ -2070,9 +2152,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -2110,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "blst",
  "cc",
@@ -2159,7 +2241,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2167,14 +2249,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -2237,7 +2319,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2255,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2269,13 +2351,12 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
- "core2",
  "multibase",
- "multihash 0.19.3",
+ "multihash",
  "unsigned-varint 0.8.0",
 ]
 
@@ -2294,7 +2375,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -2311,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2321,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2334,30 +2415,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.65"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coarsetime"
@@ -2408,14 +2489,14 @@ dependencies = [
  "nom 7.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2477,12 +2558,12 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2521,11 +2602,12 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -2602,15 +2684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,37 +2712,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64"
-version = "0.122.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.123.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
+checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
+checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
+checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2677,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
+checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2690,12 +2772,12 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
  "regalloc2 0.12.2",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -2704,36 +2786,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
+checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
+checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
+checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
+checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2742,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
+checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2754,15 +2837,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
+checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
+checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2771,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
+checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
 
 [[package]]
 name = "crc"
@@ -2786,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -2878,6 +2961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2948,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2965,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2988,12 +3080,13 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-parachain-inherent",
+ "cumulus-client-proof-size-recording",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
@@ -3036,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3068,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3091,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3119,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3130,7 +3223,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3141,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3160,6 +3253,7 @@ dependencies = [
  "sc-network",
  "sp-api",
  "sp-consensus",
+ "sp-core",
  "sp-maybe-compressed-blob",
  "sp-runtime",
  "sp-version",
@@ -3167,9 +3261,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-client-proof-size-recording"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-blockchain",
+ "sp-runtime",
+ "sp-trie",
+]
+
+[[package]]
 name = "cumulus-client-service"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3177,6 +3283,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
+ "cumulus-client-proof-size-recording",
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "cumulus-relay-chain-inprocess-interface",
@@ -3203,6 +3310,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-crypto-ec-utils",
  "sp-io",
  "sp-runtime",
  "sp-transaction-pool",
@@ -3212,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3229,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3246,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -3254,6 +3362,8 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
+ "derive-where",
+ "docify",
  "environmental",
  "frame-benchmarking",
  "frame-support",
@@ -3264,10 +3374,13 @@ dependencies = [
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
+ "sp-api",
  "sp-consensus-babe",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-externalities",
  "sp-inherents",
  "sp-io",
@@ -3284,18 +3397,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3308,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3323,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3342,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3357,9 +3470,10 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "approx",
+ "bitflags 1.3.2",
  "bounded-collections 0.3.2",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
@@ -3383,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3398,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3407,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3424,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3438,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3448,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3465,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3475,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3492,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3520,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3533,6 +3647,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-state-machine",
+ "sp-storage",
  "sp-version",
  "thiserror 1.0.69",
 ]
@@ -3540,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3576,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3609,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3623,13 +3738,15 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-consensus-babe",
  "sp-core",
+ "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
@@ -3642,7 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -3659,7 +3776,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3677,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbda285ba6e5866529faf76352bdf73801d9b44a6308d7cd58ca2379f378e994"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
 dependencies = [
  "cc",
  "cxx-build",
@@ -3692,49 +3809,49 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9efde466c5d532d57efd92f861da3bdb7f61e369128ce8b4c3fe0c9de4fa4d"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb93799095bccd4f763ca07997dc39a69e5e61ab52d2c407d4988d21ce144d"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092010228026e143b32a4463ed9fa8f86dca266af4bf5f3b2a26e113dbe4e45"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d72ebfcd351ae404fb00ff378dfc9571827a00722c9e735c9181aec320ba0a"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3749,12 +3866,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -3768,22 +3885,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "serde",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3794,18 +3910,18 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3823,15 +3939,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -3839,12 +3955,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3887,7 +4003,7 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom 7.1.3",
  "num-bigint",
@@ -3897,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3924,18 +4040,18 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3948,7 +4064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3977,7 +4093,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3990,7 +4106,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -4026,8 +4142,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle 2.6.1",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -4083,13 +4209,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4113,9 +4239,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "termcolor",
- "toml 0.8.23",
+ "toml",
  "walkdir",
 ]
 
@@ -4161,7 +4287,7 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4212,13 +4338,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
@@ -4235,14 +4361,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -4294,7 +4420,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4334,7 +4460,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4354,7 +4480,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4365,7 +4491,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4379,14 +4505,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.11.8"
+name = "env_filter"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
- "env_filter",
+ "env_filter 1.0.1",
  "jiff",
  "log",
 ]
@@ -4431,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "alloy-core",
 ]
@@ -4500,7 +4636,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4510,10 +4646,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "fastbloom"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher 1.0.3",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -4554,11 +4702,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.13.0",
- "proc-macro-crate 3.4.0",
+ "indexmap 2.14.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4599,13 +4747,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4626,9 +4773,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -4675,7 +4822,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4701,15 +4848,19 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "anyhow",
  "frame-support",
  "frame-support-procedural",
  "frame-system",
@@ -4732,16 +4883,18 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "Inflector",
+ "anyhow",
  "array-bytes 6.2.3",
  "chrono",
  "clap",
  "comfy-table",
  "cumulus-client-parachain-inherent",
+ "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
- "env_filter",
+ "env_filter 0.1.4",
  "frame-benchmarking",
  "frame-storage-access-test-runtime",
  "frame-support",
@@ -4767,12 +4920,14 @@ dependencies = [
  "sc-runtime-utilities",
  "sc-service",
  "sc-sysinfo",
+ "sc-virtualization",
  "serde",
  "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-database",
  "sp-externalities",
  "sp-genesis-builder",
@@ -4787,6 +4942,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
+ "sp-virtualization",
  "sp-wasm-interface",
  "subxt",
  "subxt-signer",
@@ -4797,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4810,33 +4966,35 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e56c0e51972d7b26ff76966c4d0f2307030df9daa5ce0885149ece1ab7ca5ad"
+checksum = "c470df86cf28818dd3cd2fc4667b80dbefe2236c722c3dc1d09e7c6c82d6dfcd"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-decode",
+ "scale-encode",
  "scale-info",
  "scale-type-resolver",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4853,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4883,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4899,7 +5057,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "indicatif",
@@ -4909,7 +5067,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
@@ -4921,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4935,12 +5093,13 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
  "binary-merkle-tree",
  "bitflags 1.3.2",
+ "derive-where",
  "docify",
  "environmental",
  "frame-metadata",
@@ -4976,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4989,36 +5148,36 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "syn 2.0.114",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5037,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5051,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5061,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5106,9 +5265,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5131,9 +5290,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5141,27 +5300,26 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -5178,13 +5336,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5200,27 +5358,31 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5230,7 +5392,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -5249,7 +5410,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "debugid",
  "fxhash",
  "serde",
@@ -5259,7 +5420,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -5322,9 +5483,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -5354,7 +5528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
  "stable_deref_trait",
 ]
 
@@ -5363,6 +5536,11 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -5371,13 +5549,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
+name = "gloo-net"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http 1.4.1",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db155b537cb791b133341f99f68371d86ee7fa4c79aacfbc376d72d23c70531"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5423,7 +5647,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5432,17 +5656,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
+ "http 1.4.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5523,6 +5747,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
  "serde",
@@ -5618,7 +5853,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring 0.17.14",
  "thiserror 2.0.18",
  "tinyvec",
@@ -5661,7 +5896,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -5721,9 +5956,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -5747,7 +5982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -5758,7 +5993,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -5792,6 +6027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,22 +6061,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -5840,17 +6083,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -5858,20 +6100,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "libc",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -5879,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5903,12 +6144,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -5916,9 +6158,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -5929,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -5943,15 +6185,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5963,15 +6205,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -5981,6 +6223,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -6001,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -6011,19 +6259,19 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
@@ -6039,7 +6287,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6116,7 +6364,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6151,12 +6399,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -6215,21 +6463,22 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -6304,9 +6553,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ittapi"
@@ -6350,17 +6599,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319af585c4c8a6b5552a52b7787a1ab3e4d59df7614190b1f85b9b842488789d"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -6371,13 +6620,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6389,7 +6638,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -6398,9 +6647,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -6414,19 +6685,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -6434,6 +6707,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
  "tracing",
@@ -6441,13 +6715,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
+checksum = "b3e1420b1792cff778e2a1ebaa44115f156ee62a94dd106eaa51163f037d2023"
 dependencies = [
  "base64",
+ "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "gloo-net",
+ "http 1.4.1",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -6464,40 +6740,41 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
  "rand 0.8.6",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
+checksum = "c215647e43482d478a6c21f021a013b50d64cf63431c1176eda9ef925dc54ec8"
 dependencies = [
  "async-trait",
  "base64",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -6515,28 +6792,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
+checksum = "f5248249c016692f1465a753057ae8347681995dd490c2cb65c48b14b46215a8"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
+checksum = "c625c78b8d545478370b6e7a2a191b0d921f831a9eef38dc1e7efb57e7a5472f"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -6555,23 +6832,34 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.10"
+name = "jsonrpsee-wasm-client"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
+checksum = "735df2088674c87f7fecdf51c80878a7aa19a8116b32d703b000f5b1a7acf95a"
 dependencies = [
- "http 1.4.0",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.24.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df5bd5c38c0906a6e8b3a38c8c22cc8525fda25fd1a03a3fe010686aea66b70"
+dependencies = [
+ "http 1.4.1",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -6598,14 +6886,24 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -6636,13 +6934,14 @@ checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "log",
  "node-primitives",
  "pallet-example-mbm",
  "pallet-example-tasks",
+ "pallet-transaction-storage",
  "parity-scale-codec",
  "polkadot-sdk",
  "primitive-types 0.13.1",
@@ -6653,6 +6952,21 @@ dependencies = [
  "static_assertions",
  "substrate-wasm-builder",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kvdb"
@@ -6714,15 +7028,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p"
@@ -6753,7 +7067,7 @@ dependencies = [
  "libp2p-upnp",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr 0.18.2",
+ "multiaddr",
  "pin-project",
  "rw-stream-sink",
  "thiserror 1.0.69",
@@ -6794,8 +7108,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "libp2p-identity",
- "multiaddr 0.18.2",
- "multihash 0.19.3",
+ "multiaddr",
+ "multihash",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.5",
@@ -6852,15 +7166,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
- "multihash 0.19.3",
- "quick-protobuf",
+ "multihash",
+ "prost 0.14.3",
  "rand 0.8.6",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -6948,8 +7262,8 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-identity",
- "multiaddr 0.18.2",
- "multihash 0.19.3",
+ "multiaddr",
+ "multihash",
  "once_cell",
  "quick-protobuf",
  "rand 0.8.6",
@@ -7057,7 +7371,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7145,18 +7459,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.8",
+ "yamux 0.13.10",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -7222,9 +7534,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7272,9 +7584,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lioness"
@@ -7290,15 +7602,15 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litep2p"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d903b21d57fae0e8d184c6ea0107fb5303fcab7cd2acaf5d2d9beb2807194b4a"
+checksum = "68e9c1a55534ab498c75dac677475818b74eebbdf8132cc47783e257b1921228"
 dependencies = [
  "async-trait",
  "bs58",
@@ -7309,11 +7621,13 @@ dependencies = [
  "futures",
  "futures-timer",
  "hickory-resolver 0.25.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "ip_network",
  "libc",
  "mockall",
- "multiaddr 0.17.1",
- "multihash 0.17.0",
+ "multiaddr",
+ "multihash",
+ "multihash-codetable",
  "network-interface",
  "parking_lot 0.12.5",
  "pin-project",
@@ -7338,7 +7652,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.8",
+ "yamux 0.13.10",
  "yasna",
  "zeroize",
 ]
@@ -7354,9 +7668,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -7421,13 +7735,13 @@ dependencies = [
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7439,7 +7753,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7453,7 +7767,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7464,7 +7778,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7475,7 +7789,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7492,16 +7806,16 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "matchers"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -7516,9 +7830,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memfd"
@@ -7526,7 +7840,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -7540,9 +7854,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -7565,7 +7879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -7587,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -7624,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "log",
@@ -7643,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7678,14 +7992,14 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -7706,25 +8020,6 @@ checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "log",
- "multibase",
- "multihash 0.17.0",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.2",
- "url",
-]
-
-[[package]]
-name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
@@ -7734,7 +8029,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.3",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -7756,40 +8051,47 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "blake2b_simd",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.9",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
-name = "multihash-derive"
-version = "0.8.1"
+name = "multihash-codetable"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
 dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
+ "blake2b_simd",
+ "digest 0.11.3",
+ "multihash-derive",
+ "sha2 0.11.0",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4723acdce756db211a53f01b3419dbdf63cb48cef5df86260f55309364735fbf"
+dependencies = [
+ "multihash",
+ "multihash-derive-impl",
+]
+
+[[package]]
+name = "multihash-derive-impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f932556f78452e5604cef711349d337ec081a9aa3c96e67b3127c8f5df05d550"
+dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -7814,9 +8116,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -7844,46 +8146,30 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.11.1",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -7895,12 +8181,12 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
- "futures",
+ "futures-util",
  "libc",
  "log",
  "tokio",
@@ -7920,22 +8206,23 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -7950,7 +8237,7 @@ checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -7959,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "node-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -7986,7 +8273,6 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-keystore",
  "sp-runtime",
- "sp-statement-store",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -8036,20 +8322,21 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "windows-sys 0.61.2",
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -8087,9 +8374,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -8099,7 +8386,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8165,9 +8452,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -8175,14 +8462,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8193,9 +8480,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nybbles"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -8211,9 +8498,6 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -8223,6 +8507,9 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -8241,14 +8528,14 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -8274,9 +8561,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -8308,14 +8595,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43dfaf083aef571385fccfdc3a2f8ede8d0a1863160455d4f2b014d8f7d04a3f"
 dependencies = [
  "expander",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.11.0",
  "petgraph 0.6.5",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -8330,9 +8623,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-accumulate-and-forward"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8343,7 +8650,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-runtime",
 ]
@@ -8351,7 +8658,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8369,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8385,9 +8692,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-conversion-precompiles"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-asset-conversion",
+ "pallet-revive",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8402,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8416,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8434,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8450,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8466,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "pallet-assets",
@@ -8478,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8493,18 +8815,29 @@ dependencies = [
 [[package]]
 name = "pallet-assets-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "const-crypto",
  "ethereum-standards",
+ "frame-benchmarking",
  "frame-support",
+ "frame-system",
+ "log",
  "pallet-assets",
  "pallet-revive",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8514,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8530,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8545,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8558,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8581,7 +8914,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8602,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8618,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8637,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -8662,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8679,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -8698,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8717,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -8737,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8760,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8778,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8796,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-session-benchmarking",
  "frame-benchmarking",
@@ -8816,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8833,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8847,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8877,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8908,17 +9241,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -8929,7 +9262,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8945,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8963,21 +9296,24 @@ dependencies = [
 [[package]]
 name = "pallet-dap"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
+ "sp-dap",
  "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8992,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9009,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "pallet-derivatives"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9029,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9044,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9062,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9083,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9095,6 +9431,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
@@ -9104,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9117,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9135,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "pallet-example-mbm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9150,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "pallet-example-tasks"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9166,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9184,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9202,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9224,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9240,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9259,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9274,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9285,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9298,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9314,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9333,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9351,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9363,6 +9700,7 @@ dependencies = [
  "polkadot-sdk-frame",
  "scale-info",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-runtime",
 ]
@@ -9370,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9384,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9396,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "pallet-multi-asset-bounties"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9413,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9424,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9437,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9454,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9463,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9473,7 +9811,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9484,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9502,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9522,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9532,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9547,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9571,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9589,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9600,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9618,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -9630,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9647,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9657,15 +9995,31 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-runtime",
  "verifiable",
 ]
 
 [[package]]
+name = "pallet-pgas-allowance"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9681,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9689,9 +10043,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-psm"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9709,8 +10077,11 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
@@ -9719,7 +10090,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9736,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9752,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -9779,7 +10150,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "polkavm",
- "polkavm-common",
+ "polkavm-common 0.33.0",
  "rand 0.8.6",
  "revm",
  "ripemd",
@@ -9793,6 +10164,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-runtime",
  "sp-version",
@@ -9803,34 +10175,34 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "alloy-core",
  "anyhow",
  "cargo_metadata",
  "hex",
  "pallet-revive-uapi",
- "polkavm-linker",
+ "polkavm-linker 0.30.0",
  "serde_json",
  "sp-core",
  "sp-io",
- "toml 0.8.23",
+ "toml",
 ]
 
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "alloy-core",
  "bitflags 1.3.2",
@@ -9838,14 +10210,14 @@ dependencies = [
  "hex-literal",
  "pallet-revive-proc-macro",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.30.0",
  "scale-info",
 ]
 
 [[package]]
 name = "pallet-root-offences"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9861,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9874,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -9888,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -9900,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9917,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9930,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9952,7 +10324,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9968,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9980,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9997,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10018,14 +10390,13 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
- "pallet-dap",
  "pallet-staking-async-rc-client",
  "parity-scale-codec",
  "rand 0.8.6",
@@ -10033,7 +10404,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto",
+ "sp-arithmetic",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
@@ -10043,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10063,8 +10436,9 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
@@ -10075,21 +10449,14 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "staging-xcm",
-]
-
-[[package]]
-name = "pallet-staking-async-reward-fn"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
-dependencies = [
- "log",
- "sp-arithmetic",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
 name = "pallet-staking-async-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10099,18 +10466,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10119,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10129,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10145,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10162,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10177,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10195,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10213,7 +10580,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10229,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10245,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10257,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10276,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10295,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10306,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10320,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10335,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10350,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10362,9 +10729,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting-precompiles"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "alloy-core",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-revive",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10374,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -10398,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10415,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -10437,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -10457,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "pallet-revive",
@@ -10471,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10504,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "parachains-common-types"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-consensus-aura",
  "sp-core",
@@ -10514,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -10592,10 +10979,10 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10719,9 +11106,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -10729,9 +11116,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -10739,22 +11126,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
@@ -10767,7 +11154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -10777,7 +11164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -10788,7 +11175,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -10821,7 +11208,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10830,40 +11217,40 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
 name = "picosimd"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af35c838647fef3d6d052e27006ef88ea162336eee33063c50a63f163c18cdeb"
+checksum = "3f8cf1ae70818c6476eb2da0ac8f3f55ecdea41a7aa16824ea6efc4a31cccf41"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -10873,9 +11260,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -10894,14 +11281,14 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polkadot-approval-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10919,7 +11306,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10934,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fatality",
  "futures",
@@ -10957,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10979,9 +11366,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-ckb-merkle-mountain-range"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221c71b432b38e494a0fdedb5f720e4cb974edf03a0af09e5b2238dbac7e6947"
+checksum = "f70a16374b7a26b74bfb4788254f8fd64c3406034e81694142cf93f1dd59368f"
 dependencies = [
  "cfg-if",
  "itertools 0.10.5",
@@ -10990,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11015,22 +11402,28 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "async-trait",
  "bitvec",
  "fatality",
  "futures",
  "futures-timer",
+ "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "schnellru",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
+ "sp-timestamp",
  "thiserror 1.0.69",
+ "tokio",
  "tokio-util",
  "tracing-gum",
 ]
@@ -11038,7 +11431,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11049,12 +11442,12 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -11071,7 +11464,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11085,7 +11478,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11098,7 +11491,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -11106,7 +11499,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11129,7 +11522,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11147,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11179,7 +11572,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11203,7 +11596,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "futures",
@@ -11222,7 +11615,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11243,7 +11636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11258,13 +11651,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
+ "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -11272,6 +11666,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
+ "schnellru",
  "sp-application-crypto",
  "sp-keystore",
  "tracing-gum",
@@ -11280,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11294,7 +11689,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11310,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fatality",
  "futures",
@@ -11328,7 +11723,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11345,13 +11740,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fatality",
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
+ "schnellru",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -11359,7 +11755,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11378,7 +11774,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -11406,7 +11802,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11419,7 +11815,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cpu-time",
  "futures",
@@ -11435,7 +11831,8 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-ec-utils",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -11446,7 +11843,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11461,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bs58",
  "futures",
@@ -11478,7 +11875,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11503,7 +11900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11527,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11536,7 +11933,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11564,7 +11961,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fatality",
  "futures",
@@ -11594,8 +11991,9 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "array-bytes 6.2.3",
  "async-trait",
  "clap",
  "color-print",
@@ -11612,6 +12010,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "docify",
  "frame-benchmarking-cli",
+ "frame-metadata",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11635,6 +12034,7 @@ dependencies = [
  "sc-consensus-aura",
  "sc-consensus-manual-seal",
  "sc-executor",
+ "sc-hop",
  "sc-keystore",
  "sc-network",
  "sc-network-statement",
@@ -11659,6 +12059,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-genesis-builder",
+ "sp-hop",
  "sp-inherents",
  "sp-keystore",
  "sp-offchain",
@@ -11681,7 +12082,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11701,7 +12102,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.3.2",
@@ -11718,7 +12119,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "bounded-collections 0.3.2",
@@ -11747,7 +12148,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11762,7 +12163,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -11795,7 +12196,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11845,7 +12246,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -11857,7 +12258,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11905,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -11961,9 +12362,11 @@ dependencies = [
  "generate-bags",
  "mmr-gadget",
  "mmr-rpc",
+ "pallet-accumulate-and-forward",
  "pallet-alliance",
  "pallet-asset-conversion",
  "pallet-asset-conversion-ops",
+ "pallet-asset-conversion-precompiles",
  "pallet-asset-conversion-tx-payment",
  "pallet-asset-rate",
  "pallet-asset-rewards",
@@ -12039,8 +12442,10 @@ dependencies = [
  "pallet-paged-list",
  "pallet-parameters",
  "pallet-people",
+ "pallet-pgas-allowance",
  "pallet-preimage",
  "pallet-proxy",
+ "pallet-psm",
  "pallet-ranked-collective",
  "pallet-recovery",
  "pallet-referenda",
@@ -12062,7 +12467,6 @@ dependencies = [
  "pallet-staking-async",
  "pallet-staking-async-ah-client",
  "pallet-staking-async-rc-client",
- "pallet-staking-async-reward-fn",
  "pallet-staking-async-runtime-api",
  "pallet-staking-reward-curve",
  "pallet-staking-reward-fn",
@@ -12075,13 +12479,13 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
- "pallet-transaction-storage",
  "pallet-treasury",
  "pallet-tx-pause",
  "pallet-uniques",
  "pallet-utility",
  "pallet-verify-signature",
  "pallet-vesting",
+ "pallet-vesting-precompiles",
  "pallet-whitelist",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
@@ -12174,12 +12578,14 @@ dependencies = [
  "sp-core-hashing",
  "sp-core-hashing-proc-macro",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-crypto-hashing-proc-macro",
+ "sp-dap",
  "sp-database",
  "sp-debug-derive",
  "sp-externalities",
  "sp-genesis-builder",
+ "sp-hop",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
@@ -12208,6 +12614,7 @@ dependencies = [
  "sp-trie",
  "sp-version",
  "sp-version-proc-macro",
+ "sp-virtualization",
  "sp-wasm-interface",
  "sp-weights",
  "staging-chain-spec-builder",
@@ -12236,7 +12643,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12256,6 +12663,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -12271,7 +12679,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12379,7 +12787,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12399,7 +12807,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12408,23 +12816,23 @@ dependencies = [
 
 [[package]]
 name = "polkavm"
-version = "0.30.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4323d016144b2852da47cee55ca5fc33dfe7517be1f52395759f247ecc5695f6"
+checksum = "d90ece49c68657299648e20469517e22c6ec38321307bb14a69c27a33927a491"
 dependencies = [
  "libc",
  "log",
  "picosimd",
  "polkavm-assembler",
- "polkavm-common",
+ "polkavm-common 0.33.0",
  "polkavm-linux-raw",
 ]
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a873fa7ace058d6507debf5fccb1d06bd3279f5b35dbaf70dc7fe94a6c415c"
+checksum = "00010f7924647dbf6f468d85d0fcfe4c3587cfb4557ef13f3682dbece8fd57f0"
 dependencies = [
  "log",
 ]
@@ -12434,6 +12842,15 @@ name = "polkavm-common"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed1b408db93d4f49f5c651a7844682b9d7a561827b4dc6202c10356076c055c9"
+dependencies = [
+ "picosimd",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e44a9487003cf5b9fc4462bbcf105cc37d5d9b18b40edf5ed50dd20ed1fdb27"
 dependencies = [
  "blake3",
  "log",
@@ -12447,7 +12864,16 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acb4463fb0b9dbfafdc1d1a1183df4bf7afa3350d124f29d5700c6bee54556b5"
 dependencies = [
- "polkavm-derive-impl-macro",
+ "polkavm-derive-impl-macro 0.30.0",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef966bc8518a66ce12d4edb73f2c4094cae72bb23258bc9e9b2802cc9d6cd79"
+dependencies = [
+ "polkavm-derive-impl-macro 0.33.0",
 ]
 
 [[package]]
@@ -12456,10 +12882,22 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993ff45b972e09babe68adce7062c3c38a84b9f50f07b7caf393a023eaa6c74a"
 dependencies = [
- "polkavm-common",
+ "polkavm-common 0.30.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c2166ad71dd7f51dcdd0d91b70d408a8b3610fa6e94d8202dd4b7185607181"
+dependencies = [
+ "polkavm-common 0.33.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12468,8 +12906,18 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4f5352e13c1ca5f0e4d7b4a804fbb85b0e02c45cae435d101fe71081bc8ed8"
 dependencies = [
- "polkavm-derive-impl",
- "syn 2.0.114",
+ "polkavm-derive-impl 0.30.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac2ac8ec5b938e249fa97b5ebb1e6fa47000c81a25eba6bf0f13edb8d430e4"
+dependencies = [
+ "polkavm-derive-impl 0.33.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12483,16 +12931,32 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "object 0.36.7",
- "polkavm-common",
+ "polkavm-common 0.30.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046d371182d27b707e116d1637ccdc8514e0e123130139ecff62bd78d987c622"
+dependencies = [
+ "dirs",
+ "gimli 0.31.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.7",
+ "polkavm-common 0.33.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604b23cdb201979304449f53d21bfd5fb1724c03e3ea889067c9a3bf7ae33862"
+checksum = "42063d4a1c52e569f7794df27dab3e19c9fa8946184023257bdbb43eb4a94be5"
 
 [[package]]
 name = "polling"
@@ -12504,7 +12968,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -12514,7 +12978,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -12526,22 +12990,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -12560,9 +13024,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -12584,9 +13048,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -12595,15 +13059,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -12616,7 +13080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12672,21 +13136,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "thiserror 1.0.69",
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -12732,7 +13186,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12743,14 +13197,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -12789,23 +13243,23 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -12857,7 +13311,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -12876,7 +13330,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -12890,7 +13344,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12903,7 +13357,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12916,7 +13370,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12939,9 +13393,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
+checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -12951,13 +13405,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
+checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13015,9 +13469,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -13033,9 +13487,9 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring 0.17.14",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -13054,16 +13508,16 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -13073,6 +13527,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -13094,9 +13554,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -13172,9 +13632,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.2.1"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
 ]
@@ -13185,7 +13645,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -13196,9 +13656,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -13241,16 +13701,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -13293,7 +13744,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13319,38 +13770,53 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resolv-conf"
@@ -13541,7 +14007,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -13628,7 +14094,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13726,7 +14192,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13758,37 +14224,37 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.26.4",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rug"
-version = "1.28.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+checksum = "07a8857882aec59d27254b02481c709327c13de6fad1da60bfc4f9783eaaa61e"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -13798,9 +14264,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -13816,7 +14282,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.6",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
@@ -13844,9 +14310,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -13878,7 +14344,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -13896,7 +14362,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -13905,28 +14371,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -13945,9 +14411,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -13967,7 +14433,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -13992,9 +14458,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -14021,9 +14487,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 
 [[package]]
 name = "rw-stream-sink"
@@ -14075,7 +14541,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "sp-core",
@@ -14086,7 +14552,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -14118,7 +14584,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "log",
@@ -14141,7 +14607,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14156,12 +14622,12 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
  "docify",
- "memmap2 0.9.9",
+ "memmap2 0.9.10",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
@@ -14172,7 +14638,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -14183,18 +14649,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "bip39",
@@ -14236,7 +14702,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fnv",
  "futures",
@@ -14262,7 +14728,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14290,7 +14756,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -14313,7 +14779,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14344,7 +14810,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14369,7 +14835,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -14381,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14403,7 +14869,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14437,7 +14903,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14457,7 +14923,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14470,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -14487,6 +14953,7 @@ dependencies = [
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
+ "sc-client-db",
  "sc-consensus",
  "sc-network",
  "sc-network-common",
@@ -14504,7 +14971,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -14514,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14534,7 +15001,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -14570,7 +15037,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-pow"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -14595,7 +15062,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -14619,7 +15086,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -14642,7 +15109,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -14655,23 +15122,24 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
+ "sp-runtime-interface",
  "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "anyhow",
  "log",
  "parking_lot 0.12.5",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -14680,9 +15148,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-hop"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "clap",
+ "futures-timer",
+ "hex",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "polkadot-primitives",
+ "sc-transaction-pool-api",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
+ "sp-hop",
+ "sp-runtime",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "sc-informant"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "console",
  "futures",
@@ -14698,7 +15190,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -14712,7 +15204,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -14740,13 +15232,14 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec 0.6.2",
  "bytes",
+ "cid",
  "either",
  "fnv",
  "futures",
@@ -14775,6 +15268,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -14789,7 +15283,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14799,7 +15293,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -14818,7 +15312,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14839,13 +15333,16 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
+ "fastbloom",
  "futures",
+ "governor",
  "log",
  "parity-scale-codec",
+ "rand 0.8.6",
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
@@ -14860,7 +15357,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14894,7 +15391,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -14913,7 +15410,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bs58",
  "bytes",
@@ -14922,8 +15419,8 @@ dependencies = [
  "libp2p-kad",
  "litep2p",
  "log",
- "multiaddr 0.18.2",
- "multihash 0.19.3",
+ "multiaddr",
+ "multihash",
  "rand 0.8.6",
  "serde",
  "serde_with",
@@ -14934,14 +15431,14 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "num_cpus",
@@ -14968,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14977,8 +15474,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "async-channel 1.9.0",
  "futures",
  "jsonrpsee",
  "log",
@@ -14989,6 +15487,7 @@ dependencies = [
  "sc-client-api",
  "sc-mixnet",
  "sc-rpc-api",
+ "sc-statement-store",
  "sc-tracing",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -15009,7 +15508,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15030,21 +15529,24 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
  "futures",
  "governor",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ip_network",
  "jsonrpsee",
  "log",
+ "prometheus",
  "sc-rpc-api",
+ "sc-utils",
  "serde",
  "serde_json",
+ "sp-core",
  "substrate-prometheus-endpoint",
  "tokio",
  "tower",
@@ -15054,15 +15556,17 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
+ "cid",
  "futures",
  "futures-util",
  "hex",
  "itertools 0.11.0",
  "jsonrpsee",
  "log",
+ "multihash-codetable",
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -15074,6 +15578,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
+ "sp-consensus",
  "sp-core",
  "sp-rpc",
  "sp-runtime",
@@ -15087,13 +15592,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -15102,7 +15607,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "directories",
@@ -15166,7 +15671,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15177,19 +15682,24 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "async-channel 1.9.0",
+ "futures",
+ "itertools 0.11.0",
  "log",
  "parity-db",
  "parking_lot 0.12.5",
  "sc-client-api",
  "sc-keystore",
  "sc-network-statement",
+ "sc-utils",
  "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
  "sp-statement-store",
+ "sp-storage",
  "substrate-prometheus-endpoint",
  "tokio",
 ]
@@ -15197,7 +15707,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "fs4",
@@ -15210,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15229,7 +15739,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -15242,14 +15752,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "chrono",
  "futures",
@@ -15268,7 +15778,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "chrono",
  "console",
@@ -15290,29 +15800,29 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-log",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.11.0",
  "linked-hash-map",
  "parity-scale-codec",
@@ -15324,7 +15834,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -15339,11 +15849,11 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "parity-scale-codec",
  "serde",
@@ -15357,7 +15867,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -15366,6 +15876,16 @@ dependencies = [
  "parking_lot 0.12.5",
  "prometheus",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "sc-virtualization"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "log",
+ "polkavm",
+ "sp-virtualization",
 ]
 
 [[package]]
@@ -15404,7 +15924,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15429,10 +15949,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17020f2d59baabf2ddcdc20a4e567f8210baf089b8a8d4785f5fd5e716f92038"
 dependencies = [
  "darling 0.20.11",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15455,10 +15975,10 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15480,15 +16000,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884aab179aba344c67ddcd1d7dd8e3f8fee202f2e570d97ec34ec8688442a5b3"
+checksum = "b3b64809a541e8d5a59f7a9d67cc700cdf5d7f907932a83a0afdedc90db07ccb"
 dependencies = [
  "base58",
  "blake2 0.10.6",
@@ -15505,9 +16025,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -15526,9 +16046,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -15668,7 +16188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -15728,11 +16248,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -15741,9 +16261,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -15778,9 +16298,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -15800,6 +16320,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -15838,16 +16364,16 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -15866,17 +16392,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -15885,14 +16412,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15912,7 +16439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -15924,7 +16451,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -15936,8 +16463,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -15948,19 +16486,29 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -15980,6 +16528,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -16036,11 +16590,11 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df350943049174c4ae8ced56c604e28270258faec12a6a48637a7655287c9ce0"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -16057,15 +16611,15 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slice-group-by"
@@ -16076,7 +16630,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16162,8 +16716,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sha3",
- "siphasher 1.0.1",
+ "sha3 0.10.9",
+ "siphasher 1.0.3",
  "slab",
  "smallvec",
  "soketto",
@@ -16202,7 +16756,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
- "siphasher 1.0.1",
+ "siphasher 1.0.3",
  "slab",
  "smol",
  "smoldot",
@@ -16235,7 +16789,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -16268,12 +16822,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16285,7 +16839,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -16295,7 +16849,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "hash-db",
@@ -16317,21 +16871,21 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16343,7 +16897,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16357,7 +16911,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16369,8 +16923,9 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "parity-scale-codec",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -16379,7 +16934,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16398,7 +16953,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "futures",
@@ -16415,7 +16970,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16431,7 +16986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16449,7 +17004,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16457,7 +17012,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -16469,7 +17024,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16486,7 +17041,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -16497,7 +17052,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16508,9 +17063,9 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "ark-vrf",
+ "ark-vrf 0.5.0",
  "array-bytes 6.2.3",
  "bip39",
  "bitflags 1.3.2",
@@ -16539,7 +17094,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -16555,15 +17110,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
 ]
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-crypto-hashing-proc-macro",
 ]
@@ -16571,7 +17126,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "ark-bls12-377 0.5.0",
  "ark-bls12-377-ext",
@@ -16584,7 +17139,11 @@ dependencies = [
  "ark-ed-on-bls12-377-ext",
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
+ "ark-pallas",
+ "ark-pallas-ext",
  "ark-scale",
+ "ark-vesta",
+ "ark-vesta-ext",
  "sp-runtime-interface",
 ]
 
@@ -16598,37 +17157,45 @@ dependencies = [
  "byteorder",
  "digest 0.10.7",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "twox-hash 1.6.3",
 ]
 
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "twox-hash 1.6.3",
 ]
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "syn 2.0.114",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sp-dap"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "frame-support",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -16638,18 +17205,18 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16659,7 +17226,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16669,9 +17236,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-hop"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16684,7 +17261,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bytes",
  "docify",
@@ -16692,11 +17269,11 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.33.0",
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -16710,7 +17287,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16720,7 +17297,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -16731,7 +17308,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16740,8 +17317,9 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
+ "derive-where",
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
@@ -16750,7 +17328,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16761,7 +17339,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16778,7 +17356,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16791,7 +17369,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16801,7 +17379,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "backtrace",
  "regex",
@@ -16810,7 +17388,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16820,7 +17398,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -16851,12 +17429,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.33.0",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -16869,20 +17447,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16896,7 +17474,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -16909,7 +17487,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "hash-db",
  "log",
@@ -16929,11 +17507,12 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
  "ed25519-dalek",
+ "frame-support",
  "hkdf",
  "parity-scale-codec",
  "rand 0.8.6",
@@ -16943,7 +17522,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -16954,12 +17533,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16971,7 +17550,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16983,19 +17562,19 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "regex",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17004,7 +17583,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17019,7 +17598,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -17044,13 +17623,14 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
+ "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
@@ -17061,19 +17641,33 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sp-virtualization"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
+dependencies = [
+ "log",
+ "num_enum",
+ "parity-scale-codec",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-storage",
+ "strum 0.26.3",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17085,7 +17679,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -17110,9 +17704,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinners"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+checksum = "071af1a9d34b78b8db3ca4424b0ea4d87052d607dbe96287aebaccd596cabc86"
 dependencies = [
  "lazy_static",
  "maplit",
@@ -17162,7 +17756,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "1.6.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "docify",
@@ -17175,7 +17769,7 @@ dependencies = [
 [[package]]
 name = "staging-node-cli"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -17198,7 +17792,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -17216,7 +17810,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17229,12 +17823,12 @@ dependencies = [
 [[package]]
 name = "staging-tracking-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.3.2",
@@ -17255,12 +17849,13 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "environmental",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
+ "pallet-accumulate-and-forward",
  "pallet-asset-conversion",
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -17279,7 +17874,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17394,7 +17989,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17406,13 +18001,13 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "subkey"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "clap",
  "sc-cli",
@@ -17421,7 +18016,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -17446,12 +18041,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 
 [[package]]
 name = "substrate-cli-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "assert_cmd",
  "futures",
@@ -17469,7 +18064,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-support"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "jsonrpsee",
@@ -17483,7 +18078,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17503,10 +18098,10 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "prometheus",
@@ -17517,7 +18112,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -17530,7 +18125,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17547,7 +18142,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -17555,12 +18150,12 @@ dependencies = [
  "filetime",
  "jobserver",
  "parity-wasm",
- "polkavm-linker",
- "shlex",
+ "polkavm-linker 0.33.0",
+ "shlex 1.3.0",
  "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.23",
+ "toml",
  "walkdir",
  "wasm-opt",
 ]
@@ -17585,9 +18180,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.43.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c6dc0f90e23c521465b8f7e026af04a48cc6f00c51d88a8d313d33096149de"
+checksum = "15d478a97cff6a704123c9a3871eff832f8ea4a477390a8ea5fd7cfedd41bf6f"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -17620,9 +18215,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1728caecd9700391e78cc30dc298221d6f5ca0ea28258a452aa76b0b7c229842"
+checksum = "461338acd557773106546b474fbb48d47617735fd50941ddc516818006daf8a0"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -17631,15 +18226,15 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "subxt-core"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25338dd11ae34293b8d0c5807064f2e00194ba1bd84cccfa694030c8d185b941"
+checksum = "002d360ac0827c882d5a808261e06c11a5e7ad2d7c295176d5126a9af9aa5f23"
 dependencies = [
  "base58",
  "blake2 0.10.6",
@@ -17667,9 +18262,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9097ef356e534ce0b6a50b95233512afc394347b971a4f929c4830adc52bbc6f"
+checksum = "bab0c7a6504798b1c4a7dbe4cac9559560826e5df3f021efa3e9dd6393050521"
 dependencies = [
  "futures",
  "futures-util",
@@ -17684,9 +18279,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.43.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c269228a2e5de4c0c61ed872b701967ee761df0f167d5b91ecec1185bca65793"
+checksum = "fc844e7877b6fe4a4013c5836a916dee4e58fc875b98ccc18b5996db34b575c3"
 dependencies = [
  "darling 0.20.11",
  "parity-scale-codec",
@@ -17696,14 +18291,14 @@ dependencies = [
  "subxt-codegen",
  "subxt-metadata",
  "subxt-utils-fetchmetadata",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
+checksum = "1b2f2a52d97d7539febc0006d6988081150b1c1a3e4a357ca02ab5cdb34072bc"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -17716,9 +18311,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
+checksum = "dec54130c797530e6aa6a52e8ba9f95fd296d19da2f9f3e23ed5353a83573f74"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -17739,9 +18334,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
+checksum = "1bdcc9159fdcc81aca0f71f0c8c77829a671f7348958fc77fb2fb320ed59a13a"
 dependencies = [
  "base64",
  "bip32",
@@ -17769,9 +18364,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.43.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4fb8fd6b16ecd3537a29d70699f329a68c1e47f70ed1a46d64f76719146563"
+checksum = "4664a0b726f11b1d6da990872f9528be090d3570c2275c9b89ba5bbc8e764592"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -17791,9 +18386,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17802,26 +18397,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f92d01b5de07eaf324f7fca61cc6bd3d82bbc1de5b6c963e6fe79e86f36580d"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17832,7 +18415,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17852,11 +18435,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -17885,9 +18468,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -17898,7 +18481,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -17913,12 +18496,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.3",
- "windows-sys 0.60.2",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17930,7 +18513,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "testnet-parachains-constants"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17968,7 +18551,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17979,7 +18562,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18008,9 +18591,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc",
  "paste",
@@ -18019,9 +18602,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",
@@ -18069,9 +18652,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -18079,9 +18662,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -18104,20 +18687,20 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18174,15 +18757,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -18204,9 +18778,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -18217,33 +18791,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -18273,9 +18847,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -18315,7 +18889,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18341,7 +18915,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18352,13 +18926,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "expander",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18385,15 +18959,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "parking_lot 0.12.5",
- "regex-automata",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -18485,6 +19059,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1)",
  "sp-externalities",
  "sp-inherents",
  "sp-io",
@@ -18520,10 +19095,10 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -18558,9 +19133,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -18600,9 +19175,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -18615,9 +19190,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -18637,7 +19212,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle 2.6.1",
 ]
 
@@ -18707,11 +19282,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -18736,7 +19311,7 @@ checksum = "225eaa083192400abfe78838e3089c539a361e0dd9b6884f61b5c6237676ec01"
 dependencies = [
  "ark-scale",
  "ark-serialize 0.5.0",
- "ark-vrf",
+ "ark-vrf 0.1.1",
  "bounded-collections 0.1.9",
  "derive-where",
  "parity-scale-codec",
@@ -18774,7 +19349,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "zeroize",
 ]
 
@@ -18794,6 +19369,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "w3f-pcs"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea1046a1deb6d26c34ba2d1f1bab4222d695d126502ee765f80b021753cb674"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "merlin",
+]
+
+[[package]]
 name = "w3f-plonk-common"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18807,7 +19396,23 @@ dependencies = [
  "getrandom_or_panic",
  "rand_core 0.6.4",
  "rayon",
- "w3f-pcs",
+ "w3f-pcs 0.0.2",
+]
+
+[[package]]
+name = "w3f-plonk-common"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30408cda37b81bd7257319942584c794c5784d00d749757bc664656749a1472a"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "getrandom_or_panic",
+ "rand_core 0.6.4",
+ "w3f-pcs 0.0.5",
 ]
 
 [[package]]
@@ -18823,8 +19428,24 @@ dependencies = [
  "ark-std 0.5.0",
  "ark-transcript",
  "rayon",
- "w3f-pcs",
- "w3f-plonk-common",
+ "w3f-pcs 0.0.2",
+ "w3f-plonk-common 0.0.2",
+]
+
+[[package]]
+name = "w3f-ring-proof"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cbfc4cb881a934e6f33c25927bf955d0cb18e52b94528bbc5fa28dddedb4cd1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "ark-transcript",
+ "w3f-pcs 0.0.5",
+ "w3f-plonk-common 0.0.7",
 ]
 
 [[package]]
@@ -18863,11 +19484,20 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -18881,9 +19511,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -18894,23 +19524,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -18918,34 +19544,44 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -18955,6 +19591,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -19099,20 +19747,32 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -19126,48 +19786,48 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
+checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bumpalo",
  "cc",
  "cfg-if",
  "fxprof-processed-profile",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object 0.37.3",
  "once_cell",
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
@@ -19180,68 +19840,68 @@ dependencies = [
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
+checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.31.1",
- "indexmap 2.13.0",
+ "gimli 0.32.3",
+ "indexmap 2.14.0",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser 0.235.0",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
+checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
+checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
 dependencies = [
  "anyhow",
  "base64",
  "directories-next",
  "log",
  "postcard",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml 0.8.23",
- "windows-sys 0.59.0",
+ "toml",
+ "windows-sys 0.60.2",
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
+checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -19250,15 +19910,15 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-versioned-export-macros",
@@ -19266,95 +19926,95 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
+checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d8693995ab3df48e88777b6ee3b2f441f2c4f895ab938996cdac3db26f256c"
+checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
 dependencies = [
  "cc",
- "object 0.36.7",
- "rustix 1.1.3",
+ "object 0.37.3",
+ "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
+checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
+checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
+checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
+checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object 0.36.7",
+ "object 0.37.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
+checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
+checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli 0.31.1",
- "object 0.36.7",
+ "gimli 0.32.3",
+ "object 0.37.3",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -19362,9 +20022,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -19386,14 +20046,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.5",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -19407,7 +20067,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19422,6 +20082,7 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal",
  "log",
+ "pallet-accumulate-and-forward",
  "pallet-asset-rate",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -19430,7 +20091,6 @@ dependencies = [
  "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
- "pallet-conviction-voting",
  "pallet-delegated-staking",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
@@ -19439,7 +20099,6 @@ dependencies = [
  "pallet-identity",
  "pallet-indices",
  "pallet-message-queue",
- "pallet-meta-tx",
  "pallet-migrations",
  "pallet-mmr",
  "pallet-multisig",
@@ -19451,8 +20110,6 @@ dependencies = [
  "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-recovery",
- "pallet-referenda",
  "pallet-root-offences",
  "pallet-root-testing",
  "pallet-scheduler",
@@ -19466,11 +20123,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
  "pallet-utility",
- "pallet-verify-signature",
  "pallet-vesting",
- "pallet-whitelist",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
@@ -19491,6 +20145,7 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-dap",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -19515,13 +20170,14 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
+ "sp-dap",
  "sp-runtime",
  "sp-weights",
  "staging-xcm",
@@ -19577,19 +20233,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
+checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli 0.31.1",
+ "gimli 0.32.3",
  "regalloc2 0.12.2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -19607,12 +20263,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.53.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -19626,16 +20293,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
@@ -19643,8 +20300,19 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -19655,7 +20323,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19666,7 +20334,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19676,12 +20344,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -19817,6 +20497,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -20001,21 +20690,20 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
 ]
 
 [[package]]
@@ -20023,12 +20711,100 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -20074,7 +20850,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
@@ -20088,18 +20864,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20113,7 +20889,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#11be995be95ac1e25a5b2a6dd941006e7097bffc"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=e1c5425b23f1#e1c5425b23f1b0c14974075c8dfa89f12959ed6e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -20163,16 +20939,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "static_assertions",
  "web-time",
 ]
@@ -20194,9 +20970,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -20205,55 +20981,55 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "synstructure 0.13.2",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -20273,14 +21049,14 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -20289,9 +21065,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -20300,20 +21076,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,42 +36,45 @@ zstd = { version = "~0.13", default-features = false }
 # Integration test-only dependency.
 # Across the whole workspace, it is used solely as a dev dependency; thus it may be pinned to a git revision
 # without impacting publication to crates.io .
-substrate-cli-test-utils = { git = "https://github.com/paritytech/polkadot-sdk" }
+substrate-cli-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
-# Polkadot SDK (master - with multi-RPC support in frame-remote-externalities from PR #10779)
-frame-remote-externalities = { git = "https://github.com/paritytech/polkadot-sdk" }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk" }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk" }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk" }
+# Polkadot SDK (master @ e1c5425b23f1, 2026-05-29)
+frame-remote-externalities = { version = "~0.35", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+frame-try-runtime = { version = "~0.34", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+frame-support = { version = "~28.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+frame-system = { version = "~28.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk" }
+sc-cli = { version = "~0.36", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1", default-features = false }
+sc-executor = { version = "~0.32", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sc-service = { version = "~0.35", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-rpc = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-transaction-storage-proof = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk" }
+sp-api = { version = "~26.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-consensus-aura = { version = "~0.32", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-consensus-babe = { version = "~0.32", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-core = { version = "~28.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-crypto-hashing = { version = "~0.1", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-externalities = { version = "~0.25", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-inherents = { version = "~26.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-io = { version = "~30.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-keystore = { version = "~0.34", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-rpc = { version = "~26.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-runtime = { version = "~31.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-state-machine = { version = "~0.35", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-storage = { version = "~19.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-std = { version = "~14.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-timestamp = { version = "~26.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-transaction-storage-proof = { version = "~26.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-version = { version = "~29.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+sp-weights = { version = "~27.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
-substrate-rpc-client = { git = "https://github.com/paritytech/polkadot-sdk" }
+substrate-rpc-client = { version = "~0.33", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk" }
-cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk" }
-cumulus-client-parachain-inherent = { git = "https://github.com/paritytech/polkadot-sdk" }
+polkadot-primitives = { version = "~7.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+cumulus-primitives-parachain-inherent = { version = "~0.7", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+cumulus-primitives-core = { version = "~0.7", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+cumulus-client-parachain-inherent = { version = "~0.1", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
 # Local
 try-runtime-core = { path = "core" }
+
+

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ sp-api = { workspace = true }
 sp-consensus-aura = { workspace = true }
 sp-consensus-babe = { workspace = true }
 sp-core = { workspace = true }
+sp-crypto-hashing = { workspace = true }
 sp-externalities = { workspace = true }
 sp-inherents = { workspace = true }
 sp-io = { workspace = true }

--- a/core/src/commands/on_runtime_upgrade/mbms.rs
+++ b/core/src/commands/on_runtime_upgrade/mbms.rs
@@ -3,7 +3,8 @@ use std::{fmt::Debug, ops::DerefMut, str::FromStr, sync::Arc, time::Duration};
 use log::Level;
 use parity_scale_codec::{Codec, Encode};
 use sc_executor::sp_wasm_interface::HostFunctions;
-use sp_core::{twox_128, Hasher, H256};
+use sp_core::{Hasher, H256};
+use sp_crypto_hashing::twox_128;
 use sp_runtime::{
     traits::{Block as BlockT, NumberFor},
     DeserializeOwned, ExtrinsicInclusionMode,

--- a/core/src/commands/on_runtime_upgrade/mod.rs
+++ b/core/src/commands/on_runtime_upgrade/mod.rs
@@ -25,7 +25,8 @@ use frame_try_runtime::UpgradeCheckSelect;
 use log::Level;
 use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
-use sp_core::{hexdisplay::HexDisplay, twox_128, Hasher, H256};
+use sp_core::{hexdisplay::HexDisplay, Hasher, H256};
+use sp_crypto_hashing::twox_128;
 use sp_runtime::{
     traits::{Block as BlockT, HashingFor, NumberFor},
     DeserializeOwned,

--- a/core/src/common/empty_block/inherents/custom_idps/para_parachain.rs
+++ b/core/src/common/empty_block/inherents/custom_idps/para_parachain.rs
@@ -23,7 +23,7 @@ use std::{ops::DerefMut, sync::Arc};
 use parity_scale_codec::{Decode, Encode};
 use polkadot_primitives::HeadData;
 use sp_consensus_babe::SlotDuration;
-use sp_core::twox_128;
+use sp_crypto_hashing::twox_128;
 use sp_inherents::InherentIdentifier;
 use sp_runtime::traits::{Block as BlockT, HashingFor};
 use sp_state_machine::TestExternalities;

--- a/core/src/common/empty_block/inherents/pre_apply.rs
+++ b/core/src/common/empty_block/inherents/pre_apply.rs
@@ -17,7 +17,8 @@
 
 use cumulus_primitives_parachain_inherent::MessageQueueChain;
 use parity_scale_codec::Encode;
-use sp_core::{twox_128, H256};
+use sp_core::H256;
+use sp_crypto_hashing::twox_128;
 use sp_runtime::traits::{Block as BlockT, HashingFor};
 use sp_state_machine::TestExternalities;
 

--- a/core/src/common/state.rs
+++ b/core/src/common/state.rs
@@ -27,8 +27,9 @@ use sc_executor::{
 };
 use sp_api::{CallContext, StorageProof};
 use sp_core::{
-    hexdisplay::HexDisplay, storage::well_known_keys, traits::ReadRuntimeVersion, twox_128, Hasher,
+    hexdisplay::HexDisplay, storage::well_known_keys, traits::ReadRuntimeVersion, Hasher,
 };
+use sp_crypto_hashing::twox_128;
 use sp_externalities::Extensions;
 use sp_runtime::{
     traits::{BlakeTwo256, Block as BlockT, HashingFor, Header as HeaderT},
@@ -382,7 +383,11 @@ pub(crate) fn state_machine_call<Block: BlockT, HostFns: HostFunctions>(
         method,
         data,
         &mut extensions,
-        &sp_state_machine::backend::BackendRuntimeCode::new(&ext.backend).runtime_code()?,
+        &sp_state_machine::backend::BackendRuntimeCode::new(
+            &ext.backend,
+            sp_state_machine::backend::TryPendingCode::No,
+        )
+        .runtime_code()?,
         CallContext::Offchain,
     )
     .execute()
@@ -405,7 +410,10 @@ pub(crate) fn state_machine_call_with_proof<Block: BlockT, HostFns: HostFunction
     mut extensions: Extensions,
     maybe_export_proof: Option<PathBuf>,
 ) -> sc_cli::Result<(StorageProof, Vec<u8>)> {
-    let runtime_code_backend = sp_state_machine::backend::BackendRuntimeCode::new(&ext.backend);
+    let runtime_code_backend = sp_state_machine::backend::BackendRuntimeCode::new(
+        &ext.backend,
+        sp_state_machine::backend::TryPendingCode::No,
+    );
     let proving_backend = TrieBackendBuilder::wrap(&ext.backend)
         .with_recorder(Default::default())
         .build();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.93.0"
 components = [
 	"rust-src",
 	"rustc-dev",


### PR DESCRIPTION
## Summary

- Pin all polkadot-sdk dependencies to master commit `e1c5425b23f1` (2026-05-29) with explicit `rev` and version bounds.
- This brings in litep2p v0.14.0, which drops the yanked `core2` crate that was breaking CI.
- Fix two API breaks: `twox_128` moved from `sp-core` to `sp-crypto-hashing`, and `BackendRuntimeCode::new` now requires a `TryPendingCode` argument.