### PR TITLE
Register storage-proof-size host function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19010,6 +19010,7 @@ version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "clap",
+ "cumulus-primitives-proof-size-hostfunction",
  "env_logger",
  "frame-remote-externalities",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ substrate-rpc-client = { version = "~0.33", git = "https://github.com/paritytech
 polkadot-primitives = { version = "~7.0", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 cumulus-primitives-parachain-inherent = { version = "~0.7", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 cumulus-primitives-core = { version = "~0.7", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
+cumulus-primitives-proof-size-hostfunction = { version = "~0.2", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 cumulus-client-parachain-inherent = { version = "~0.1", git = "https://github.com/paritytech/polkadot-sdk", rev = "e1c5425b23f1" }
 
 # Local

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 
 sp-io = { workspace = true }
+cumulus-primitives-proof-size-hostfunction = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-state-machine = { workspace = true }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -360,7 +360,10 @@ async fn main() {
     init_env();
 
     let cmd = TryRuntime::parse();
-    cmd.run::<Block<Header<u32, BlakeTwo256>, OpaqueExtrinsic>, sp_io::SubstrateHostFunctions>()
+    cmd.run::<Block<Header<u32, BlakeTwo256>, OpaqueExtrinsic>, (
+        sp_io::SubstrateHostFunctions,
+        cumulus_primitives_proof_size_hostfunction::storage_proof_size::HostFunctions,
+    )>()
         .await
         .unwrap();
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -360,6 +360,11 @@ async fn main() {
     init_env();
 
     let cmd = TryRuntime::parse();
+    // The cumulus `storage_proof_size` host function must be registered in addition to the
+    // substrate ones: runtimes built with `cumulus-pallet-weight-reclaim` (all current system
+    // chains) call it during the dispatch of every signed extrinsic, and block execution traps
+    // with "call to a missing function" if it is absent. Without proof recording (the case
+    // here) it returns `u64::MAX`, which weight-reclaim interprets as "recording disabled".
     cmd.run::<Block<Header<u32, BlakeTwo256>, OpaqueExtrinsic>, (
         sp_io::SubstrateHostFunctions,
         cumulus_primitives_proof_size_hostfunction::storage_proof_size::HostFunctions,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -364,6 +364,6 @@ async fn main() {
         sp_io::SubstrateHostFunctions,
         cumulus_primitives_proof_size_hostfunction::storage_proof_size::HostFunctions,
     )>()
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
## Problem

`execute-block` and `follow-chain` fail on blocks that contain signed extrinsics, for any runtime that uses `cumulus-pallet-weight-reclaim`:

```
Execution aborted due to trap: call to a missing function
env:ext_storage_proof_size_storage_proof_size_version_1
```

The CLI registers only `sp_io::SubstrateHostFunctions`. The weight-reclaim transaction extension calls the cumulus `storage_proof_size` host function on every signed extrinsic. The executor cannot resolve it, so block execution traps.

All current system-chain runtimes use this pallet (checked: 9 runtimes in polkadot-sdk, 11 in runtimes). The two commands are therefore unusable against modern parachains.

## Fix

Register `cumulus_primitives_proof_size_hostfunction::storage_proof_size::HostFunctions` next to the substrate host functions. One line in `cli/main.rs`, plus the dependency.

When no proof recording is active, the host function returns `u64::MAX`. Weight-reclaim treats that as "recording disabled" and skips reclaim. This is the correct behavior for try-runtime execution.

## Validation

Controlled A/B on a local `asset-hub-westend` dev chain (omni-node, runtime with `try-runtime` feature):

| Binary | Block content | Result |
|---|---|---|
| unpatched | only inherents (block 486) | executes |
| unpatched | one signed `Balances::transfer_keep_alive` (block 487) | trap: missing function |
| patched | same block 487 | `Block #487 successfully executed` |

The empty-block success explains why the bug can go unnoticed: it only appears when a block carries a signed extrinsic.

Also verified against ~500 blocks with `follow-chain --try-state Proxy` on the same chain: no traps, try-state hooks run per block.